### PR TITLE
Revert "chore(deps-dev): bump typescript from 5.4.5 to 5.5.2 in the builder group"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "ts-patch": "^3.2.0",
-        "typescript": "^5.5.2",
+        "typescript": "^5.4.5",
         "typescript-transform-paths": "^3.4.6",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
@@ -9723,9 +9723,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.1",
     "ts-patch": "^3.2.0",
-    "typescript": "^5.5.2",
+    "typescript": "^5.4.5",
     "typescript-transform-paths": "^3.4.6",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",


### PR DESCRIPTION
Reverts wrtnio/connectors#93

아직 typia 버전이 타입스크립트 5.5버전을 지원하지 않기 때문에 revert 합니다.