### PR TITLE
chore: google `ISecret` 타입 정의 후 배포

### DIFF
--- a/src/api/functional/connector/gmail/get/index.ts
+++ b/src/api/functional/connector/gmail/get/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGmail } from "../../../../structures/connector/gmail/IGmail";
 
 /**
@@ -99,9 +98,7 @@ export async function findEmail(
       );
 }
 export namespace findEmail {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://mail.google.com/"]>
-  >;
+  export type Input = Primitive<IGmail.ISecret>;
   export type Output = Primitive<IGmail.IFindGmailOutput>;
 
   export const METADATA = {

--- a/src/api/functional/connector/gmail/index.ts
+++ b/src/api/functional/connector/gmail/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../structures/connector/common/ISecretValue";
 import type { IGmail } from "../../../structures/connector/gmail/IGmail";
 
 export * as get from "./get";
@@ -481,9 +480,7 @@ export async function removeMail(
       );
 }
 export namespace removeMail {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://mail.google.com/"]>
-  >;
+  export type Input = Primitive<IGmail.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_calendar/event/index.ts
+++ b/src/api/functional/connector/google_calendar/event/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleCalendar } from "../../../../structures/connector/google_calendar/IGoogleCalendar";
 
 export * as attendees from "./attendees";
@@ -385,9 +384,7 @@ export async function deleteEvent(
       );
 }
 export namespace deleteEvent {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/calendar"]>
-  >;
+  export type Input = Primitive<IGoogleCalendar.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_calendar/get_list/index.ts
+++ b/src/api/functional/connector/google_calendar/get_list/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleCalendar } from "../../../../structures/connector/google_calendar/IGoogleCalendar";
 
 /**
@@ -102,9 +101,7 @@ export async function readCalenders(
       );
 }
 export namespace readCalenders {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/calendar"]>
-  >;
+  export type Input = Primitive<IGoogleCalendar.ISecret>;
   export type Output = Primitive<Array<IGoogleCalendar.IGoogleCalendarOutput>>;
 
   export const METADATA = {

--- a/src/api/functional/connector/google_calendar/index.ts
+++ b/src/api/functional/connector/google_calendar/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../structures/connector/common/ISecretValue";
 import type { IGoogleCalendar } from "../../../structures/connector/google_calendar/IGoogleCalendar";
 
 export * as get_list from "./get_list";
@@ -240,9 +239,7 @@ export async function deleteCalendar(
       );
 }
 export namespace deleteCalendar {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/calendar"]>
-  >;
+  export type Input = Primitive<IGoogleCalendar.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_docs/get/index.ts
+++ b/src/api/functional/connector/google_docs/get/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDocs } from "../../../../structures/connector/google_docs/IGoogleDocs";
 
 /**
@@ -103,15 +102,7 @@ export async function readDocs(
       );
 }
 export namespace readDocs {
-  export type Input = Primitive<
-    ICommon.ISecret<
-      "google",
-      [
-        "https://www.googleapis.com/auth/drive",
-        "https://www.googleapis.com/auth/documents",
-      ]
-    >
-  >;
+  export type Input = Primitive<IGoogleDocs.ISecret>;
   export type Output = Primitive<IGoogleDocs.IReadGoogleDocsOutput>;
 
   export const METADATA = {

--- a/src/api/functional/connector/google_docs/get_list/index.ts
+++ b/src/api/functional/connector/google_docs/get_list/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDocs } from "../../../../structures/connector/google_docs/IGoogleDocs";
 
 /**
@@ -100,15 +99,7 @@ export async function list(
       );
 }
 export namespace list {
-  export type Input = Primitive<
-    ICommon.ISecret<
-      "google",
-      [
-        "https://www.googleapis.com/auth/drive",
-        "https://www.googleapis.com/auth/documents",
-      ]
-    >
-  >;
+  export type Input = Primitive<IGoogleDocs.ISecret>;
   export type Output = Primitive<IGoogleDocs.IListGoogleDocsOutput>;
 
   export const METADATA = {

--- a/src/api/functional/connector/google_docs/index.ts
+++ b/src/api/functional/connector/google_docs/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../structures/connector/common/ISecretValue";
 import type { IGoogleDocs } from "../../../structures/connector/google_docs/IGoogleDocs";
 
 export * as get from "./get";
@@ -362,15 +361,7 @@ export async function deleteById(
       );
 }
 export namespace deleteById {
-  export type Input = Primitive<
-    ICommon.ISecret<
-      "google",
-      [
-        "https://www.googleapis.com/auth/drive",
-        "https://www.googleapis.com/auth/documents",
-      ]
-    >
-  >;
+  export type Input = Primitive<IGoogleDocs.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_drive/file/index.ts
+++ b/src/api/functional/connector/google_drive/file/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDrive } from "../../../../structures/connector/google_drive/IGoogleDrive";
 
 export * as text from "./text";
@@ -287,9 +286,7 @@ export async function deleteFile(
       );
 }
 export namespace deleteFile {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/drive"]>
-  >;
+  export type Input = Primitive<IGoogleDrive.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_drive/folder/index.ts
+++ b/src/api/functional/connector/google_drive/folder/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDrive } from "../../../../structures/connector/google_drive/IGoogleDrive";
 
 /**
@@ -285,9 +284,7 @@ export async function deleteFolder(
       );
 }
 export namespace deleteFolder {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/drive"]>
-  >;
+  export type Input = Primitive<IGoogleDrive.ISecret>;
 
   export const METADATA = {
     method: "DELETE",

--- a/src/api/functional/connector/google_drive/get/file/index.ts
+++ b/src/api/functional/connector/google_drive/get/file/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDrive } from "../../../../../structures/connector/google_drive/IGoogleDrive";
 
 /**
@@ -129,9 +128,7 @@ export async function readFile(
       );
 }
 export namespace readFile {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/drive"]>
-  >;
+  export type Input = Primitive<IGoogleDrive.ISecret>;
   export type Output = Primitive<IGoogleDrive.IReadFileGoogleDriveOutput>;
 
   export const METADATA = {

--- a/src/api/functional/connector/google_drive/get/folders/index.ts
+++ b/src/api/functional/connector/google_drive/get/folders/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../../structures/connector/common/ISecretValue";
 import type { IGoogleDrive } from "../../../../../structures/connector/google_drive/IGoogleDrive";
 
 /**
@@ -127,9 +126,7 @@ export async function folderList(
       );
 }
 export namespace folderList {
-  export type Input = Primitive<
-    ICommon.ISecret<"google", ["https://www.googleapis.com/auth/drive"]>
-  >;
+  export type Input = Primitive<IGoogleDrive.ISecret>;
   export type Output = Primitive<IGoogleDrive.IFolderListGoogleDriveOutput>;
 
   export const METADATA = {

--- a/src/api/functional/connector/notion/find_item_list/index.ts
+++ b/src/api/functional/connector/notion/find_item_list/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../structures/connector/common/ISecretValue";
 import type { INotion } from "../../../../structures/connector/notion/INotion";
 
 /**
@@ -85,7 +84,7 @@ export async function getDatabaseItemList(
       );
 }
 export namespace getDatabaseItemList {
-  export type Input = Primitive<ICommon.ISecret<"notion", never>>;
+  export type Input = Primitive<INotion.ISecret>;
   export type Output = Primitive<Array<INotion.IDatabaseItemOutput>>;
 
   export const METADATA = {

--- a/src/api/functional/connector/notion/get/database_info/index.ts
+++ b/src/api/functional/connector/notion/get/database_info/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../../structures/connector/common/ISecretValue";
 import type { INotion } from "../../../../../structures/connector/notion/INotion";
 
 /**
@@ -83,7 +82,7 @@ export async function getDatabaseListInfo(
       );
 }
 export namespace getDatabaseListInfo {
-  export type Input = Primitive<ICommon.ISecret<"notion", never>>;
+  export type Input = Primitive<INotion.ISecret>;
   export type Output = Primitive<Array<INotion.IDatabaseInfo>>;
 
   export const METADATA = {
@@ -197,7 +196,7 @@ export async function getDatabaseInfo(
       );
 }
 export namespace getDatabaseInfo {
-  export type Input = Primitive<ICommon.ISecret<"notion", never>>;
+  export type Input = Primitive<INotion.ISecret>;
   export type Output = Primitive<INotion.IDatabaseInfo>;
 
   export const METADATA = {

--- a/src/api/functional/connector/notion/get/page/index.ts
+++ b/src/api/functional/connector/notion/get/page/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../../structures/connector/common/ISecretValue";
 import type { INotion } from "../../../../../structures/connector/notion/INotion";
 
 /**
@@ -83,7 +82,7 @@ export async function readPageList(
       );
 }
 export namespace readPageList {
-  export type Input = Primitive<ICommon.ISecret<"notion", never>>;
+  export type Input = Primitive<INotion.ISecret>;
   export type Output = Primitive<Array<INotion.IReadPageOutput>>;
 
   export const METADATA = {

--- a/src/api/functional/connector/notion/get/users/index.ts
+++ b/src/api/functional/connector/notion/get/users/index.ts
@@ -9,7 +9,6 @@ import { NestiaSimulator } from "@nestia/fetcher/lib/NestiaSimulator";
 import { PlainFetcher } from "@nestia/fetcher/lib/PlainFetcher";
 import typia from "typia";
 
-import type { ICommon } from "../../../../../structures/connector/common/ISecretValue";
 import type { INotion } from "../../../../../structures/connector/notion/INotion";
 
 /**
@@ -83,7 +82,7 @@ export async function getUsers(
       );
 }
 export namespace getUsers {
-  export type Input = Primitive<ICommon.ISecret<"notion", never>>;
+  export type Input = Primitive<INotion.ISecret>;
   export type Output = Primitive<Array<INotion.IUserOutput>>;
 
   export const METADATA = {


### PR DESCRIPTION
- `ISecret` 정의 후 sdk 빌드가 이루어지지 않았기에 빌드 후 PR을 날립니다.