### PR TITLE
feat: Swagger 분리

### DIFF
--- a/nestia-configs/business.nestia.config.ts
+++ b/nestia-configs/business.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { BusinessModule } from "../src/swaggers/BusinessModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(BusinessModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/business.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/commerce.nestia.config.ts
+++ b/nestia-configs/commerce.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { CommerceModule } from "../src/swaggers/CommerceModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(CommerceModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/commerce.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/comunication.nestia.config.ts
+++ b/nestia-configs/comunication.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { ComunicationModule } from "../src/swaggers/ComunicationModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(ComunicationModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/comunication.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/data-analytics.nestia.config.ts
+++ b/nestia-configs/data-analytics.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { DataAnalyticsModule } from "../src/swaggers/DataAnalyticsModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(DataAnalyticsModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/data-analytics.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/education.nestia.config.ts
+++ b/nestia-configs/education.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { EducationModule } from "../src/swaggers/EducationModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(EducationModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/education.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/entertainment.nestia.config.ts
+++ b/nestia-configs/entertainment.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { EntertainmentModule } from "../src/swaggers/EntertainmentModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(EntertainmentModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/entertainment.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/graphic-design.nestia.config.ts
+++ b/nestia-configs/graphic-design.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { GraphicDesignModule } from "../src/swaggers/GraphicDesignModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(GraphicDesignModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/graphic-design.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/it-development.nestia.config.ts
+++ b/nestia-configs/it-development.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { ITDevelopmentModule } from "../src/swaggers/ITDevelopmentModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(ITDevelopmentModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/it-development.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/life-style.nestia.config.ts
+++ b/nestia-configs/life-style.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { LifeStyleModule } from "../src/swaggers/LifeStyleModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(LifeStyleModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/life-style.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/marketing.nestia.config.ts
+++ b/nestia-configs/marketing.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { MarketingModule } from "../src/swaggers/MarketingModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(MarketingModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/marketing.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/music.nestia.config copy.ts
+++ b/nestia-configs/music.nestia.config copy.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { MusicModule } from "../src/swaggers/MusicModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(MusicModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/music.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/news-media.nestia.config.ts
+++ b/nestia-configs/news-media.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { NewsMediaModule } from "../src/swaggers/NewsMediaModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(NewsMediaModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/news-media.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/open-data.nestia.config.ts
+++ b/nestia-configs/open-data.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { OpenDataModule } from "../src/controllers/connector/open_data/OpenDataModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(OpenDataModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/open-data.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/productivity.nestia.config.ts
+++ b/nestia-configs/productivity.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { ProductivityModule } from "../src/swaggers/ProductivityModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(ProductivityModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/productivity.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/research.nestia.config.ts
+++ b/nestia-configs/research.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { ResearchModule } from "../src/swaggers/ResearchModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(ResearchModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/research.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/nestia-configs/travel.nestia.config.ts
+++ b/nestia-configs/travel.nestia.config.ts
@@ -1,0 +1,28 @@
+// nestia configuration file
+import type sdk from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+import { TravelModule } from "../src/swaggers/TravelModule";
+
+const NESTIA_CONFIG: sdk.INestiaConfig = {
+  input: async () => NestFactory.create(TravelModule),
+  swagger: {
+    beautify: true,
+    decompose: true,
+    output: "packages/api/categories/travel.swagger.json",
+    servers: [
+      {
+        url: "https://studio-connector-api.wrtn.ai",
+        description: "Production Server",
+      },
+      {
+        url: "https://studio-connector-poc.dev.wrtn.club",
+        description: "Develop Server",
+      },
+      {
+        url: "http://localhost:3003",
+        description: "Local Server",
+      },
+    ],
+  },
+};
+export default NESTIA_CONFIG;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:api": "rimraf packages/api/lib && npm run build:sdk && tsc -p packages/api/tsconfig.json",
     "build:main": "rimraf lib && tsc",
     "build:sdk": "rimraf src/api/functional && node --max-old-space-size=8000 node_modules/nestia/bin sdk",
-    "build:swagger": "node --max-old-space-size=8000 node_modules/nestia/bin swagger && ts-node src/executable/openai.ts",
+    "build:swagger": "node --max-old-space-size=8000 node_modules/nestia/bin swagger && ts-node src/executable/categorize.ts && ts-node src/executable/openai.ts",
     "build:test": "rimraf bin && tsc -p test/tsconfig.json",
     "dev": "npm run build:test -- --watch",
     "eslint": "eslint src && eslint test",

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -6,3 +6,5 @@ openai-positional.json
 openai-keyword.json
 swagger.json
 version.json
+
+categories/*.swagger.json

--- a/src/api/functional/connector/index.ts
+++ b/src/api/functional/connector/index.ts
@@ -11,14 +11,7 @@ import typia from "typia";
 
 import type { IRanker } from "../../structures/connector/sort/IRanker";
 
-export * as arxiv_search from "./arxiv_search";
-export * as daum from "./daum";
-export * as naver from "./naver";
-export * as youtube_search from "./youtube_search";
 export * as typeform from "./typeform";
-export * as google_scholar from "./google_scholar";
-export * as csv from "./csv";
-export * as notion from "./notion";
 export * as extract from "./extract";
 export * as marketing_copy from "./marketing_copy";
 export * as aws from "./aws";
@@ -53,6 +46,13 @@ export * as dall_e_3 from "./dall_e_3";
 export * as google_search from "./google_search";
 export * as google_shopping from "./google_shopping";
 export * as google_ads from "./google_ads";
+export * as arxiv_search from "./arxiv_search";
+export * as daum from "./daum";
+export * as naver from "./naver";
+export * as youtube_search from "./youtube_search";
+export * as google_scholar from "./google_scholar";
+export * as csv from "./csv";
+export * as notion from "./notion";
 
 /**
  * 주어진 아이템의 배열을 점수가 높은 순서대로 정렬합니다.

--- a/src/controllers/connector/ConnectorModule.ts
+++ b/src/controllers/connector/ConnectorModule.ts
@@ -1,12 +1,12 @@
 import { Module } from "@nestjs/common";
 import { LoggerModule } from "nestjs-pino";
 
-import { ArxivSearchController } from "./arxiv_search/ArxivSearchController";
+import { ArxivSearchModule } from "./arxiv_search/ArxivSearchModule";
 import { AwsModule } from "./aws/AwsModule";
 import { ChatbotModule } from "./chatbot/ChatbotModule";
-import { CsvController } from "./csv/CsvController";
+import { CsvModule } from "./csv/CsvModule";
 import { DallE3Module } from "./dall_e_3/DallE3Module";
-import { DaumController } from "./daum/DaumController";
+import { DaumModule } from "./daum/DaumModule";
 import { ExcelModule } from "./excel/ExcelModule";
 import { KeywordExtractModule } from "./extract/KeywordExtractModule";
 import { FigmaModule } from "./figma/FigmaModule";
@@ -16,7 +16,7 @@ import { GoogleSheetModule } from "./google-sheet/GoogleSheetModule";
 import { GoogleAdsModule } from "./google_ads/GoogleAdsModule";
 import { GoogleCalendarModule } from "./google_calendar/GoogleCalendarModule";
 import { GoogleDriveModule } from "./google_drive/GoogleDriveModule";
-import { GoogleScholarController } from "./google_scholar/GoogleScholarController";
+import { GoogleScholarModule } from "./google_scholar/GoolgeScholarModule";
 import { GoogleSearchModule } from "./google_search/GoogleSearchModule";
 import { GoogleShoppingModule } from "./google_shopping/GoogleShoppingModule";
 import { GoogleSlidesModule } from "./google_slides/GoogleSlidesModule";
@@ -30,8 +30,8 @@ import { KakaoTalkModule } from "./kakao_talk/KakaoTalkModule";
 import { KoreaEximbankModule } from "./korea_eximbank/KoreaEximbankModule";
 import { LlmModule } from "./llm/LlmModule";
 import { MarketingCopyModule } from "./marketing/MarketingCopyModule";
-import { NaverController } from "./naver/NaverController";
-import { NotionController } from "./notion/NotionController";
+import { NaverModule } from "./naver/NaverModule";
+import { NotionModule } from "./notion/NotionModule";
 import { OpenDataModule } from "./open_data/OpenDataModule";
 import { PromptModule } from "./prompts/PromptModule";
 import { RagModule } from "./rag/RagModule";
@@ -43,7 +43,7 @@ import { StudentReportGeneratorModule } from "./student_report_generator/Student
 import { SweetTackerModule } from "./sweet_tracker/SweetTrackerModule";
 import { ToolModule } from "./tool/ToolModule";
 import { TypeformController } from "./typeform/TypeformController";
-import { YoutubeSearchController } from "./youtube_search/YoutubeSearchController";
+import { YoutubeSearchModule } from "./youtube_search/YoutubeSearchModule";
 import { ZoomModule } from "./zoom/ZoomModule";
 
 @Module({
@@ -87,16 +87,14 @@ import { ZoomModule } from "./zoom/ZoomModule";
     GoogleSearchModule,
     GoogleShoppingModule,
     GoogleAdsModule,
+    ArxivSearchModule,
+    DaumModule,
+    NaverModule,
+    YoutubeSearchModule,
+    GoogleScholarModule,
+    CsvModule,
+    NotionModule,
   ],
-  controllers: [
-    ArxivSearchController,
-    DaumController,
-    NaverController,
-    YoutubeSearchController,
-    TypeformController,
-    GoogleScholarController,
-    CsvController,
-    NotionController,
-  ],
+  controllers: [TypeformController],
 })
 export class ConnectorModule {}

--- a/src/controllers/connector/arxiv_search/ArxivSearchModule.ts
+++ b/src/controllers/connector/arxiv_search/ArxivSearchModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { ArxivSearchController } from "./ArxivSearchController";
+
+@Module({
+  controllers: [ArxivSearchController],
+  providers: [],
+})
+export class ArxivSearchModule {}

--- a/src/controllers/connector/csv/CsvModule.ts
+++ b/src/controllers/connector/csv/CsvModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { CsvController } from "./CsvController";
+
+@Module({
+  controllers: [CsvController],
+  providers: [],
+})
+export class CsvModule {}

--- a/src/controllers/connector/daum/DaumModule.ts
+++ b/src/controllers/connector/daum/DaumModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { DaumController } from "./DaumController";
+
+@Module({
+  controllers: [DaumController],
+  providers: [],
+})
+export class DaumModule {}

--- a/src/controllers/connector/google_scholar/GoolgeScholarModule.ts
+++ b/src/controllers/connector/google_scholar/GoolgeScholarModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { GoogleScholarController } from "./GoogleScholarController";
+
+@Module({
+  controllers: [GoogleScholarController],
+  providers: [],
+})
+export class GoogleScholarModule {}

--- a/src/controllers/connector/naver/NaverModule.ts
+++ b/src/controllers/connector/naver/NaverModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { NaverController } from "./NaverController";
+
+@Module({
+  controllers: [NaverController],
+  providers: [],
+})
+export class NaverModule {}

--- a/src/controllers/connector/notion/NotionModule.ts
+++ b/src/controllers/connector/notion/NotionModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { NotionController } from "./NotionController";
+
+@Module({
+  controllers: [NotionController],
+  providers: [],
+})
+export class NotionModule {}

--- a/src/controllers/connector/youtube_search/YoutubeSearchModule.ts
+++ b/src/controllers/connector/youtube_search/YoutubeSearchModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { YoutubeSearchController } from "./YoutubeSearchController";
+
+@Module({
+  controllers: [YoutubeSearchController],
+  providers: [],
+})
+export class YoutubeSearchModule {}

--- a/src/executable/categorize.ts
+++ b/src/executable/categorize.ts
@@ -1,0 +1,20 @@
+import cp from "child_process";
+import fs from "fs";
+import { ConnectorConfiguration } from "../ConnectorConfiguration";
+
+const main = async (): Promise<void> => {
+  const location: string = ConnectorConfiguration.ROOT;
+  const files = await fs.promises.readdir(`${location}/nestia-configs`);
+  const configs = files.filter((el) => el.endsWith("nestia.config.ts"));
+
+  for await (const config of configs) {
+    const script = `node --max-old-space-size=8000 node_modules/nestia/bin swagger --config ./nestia-configs/${config}`;
+    console.log(script);
+    cp.execSync(script);
+  }
+};
+
+main().catch((exp) => {
+  console.log(exp);
+  process.exit(-1);
+});

--- a/src/swaggers/BusinessModule.ts
+++ b/src/swaggers/BusinessModule.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+import { ExcelModule } from "../controllers/connector/excel/ExcelModule";
+import { GmailModule } from "../controllers/connector/gmail/GmailModule";
+import { GoogleDocsModule } from "../controllers/connector/google-docs/GoogleDocsModule";
+import { GoogleSheetModule } from "../controllers/connector/google-sheet/GoogleSheetModule";
+import { GoogleCalendarModule } from "../controllers/connector/google_calendar/GoogleCalendarModule";
+import { GoogleDriveModule } from "../controllers/connector/google_drive/GoogleDriveModule";
+import { GoogleSlidesModule } from "../controllers/connector/google_slides/GoogleSlidesModule";
+import { HwpModule } from "../controllers/connector/hwp/HwpModule";
+
+@Module({
+  imports: [
+    HwpModule,
+    ExcelModule,
+    GoogleDocsModule,
+    GoogleSheetModule,
+    GoogleCalendarModule,
+    GoogleDriveModule,
+    GmailModule,
+    GoogleSlidesModule,
+  ],
+})
+export class BusinessModule {}

--- a/src/swaggers/CommerceModule.ts
+++ b/src/swaggers/CommerceModule.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { GoogleShoppingModule } from "../controllers/connector/google_shopping/GoogleShoppingModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    LlmModule,
+    GoogleShoppingModule,
+  ],
+})
+export class CommerceModule {}

--- a/src/swaggers/ComunicationModule.ts
+++ b/src/swaggers/ComunicationModule.ts
@@ -1,0 +1,24 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { ChatbotModule } from "../controllers/connector/chatbot/ChatbotModule";
+import { DaumModule } from "../controllers/connector/daum/DaumModule";
+import { GmailModule } from "../controllers/connector/gmail/GmailModule";
+import { KakaoTalkModule } from "../controllers/connector/kakao_talk/KakaoTalkModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { NaverModule } from "../controllers/connector/naver/NaverModule";
+import { YoutubeSearchModule } from "../controllers/connector/youtube_search/YoutubeSearchModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    DaumModule,
+    NaverModule,
+    YoutubeSearchModule,
+    LlmModule,
+    GmailModule,
+    ChatbotModule,
+    KakaoTalkModule,
+  ],
+})
+export class ComunicationModule {}

--- a/src/swaggers/DataAnalyticsModule.ts
+++ b/src/swaggers/DataAnalyticsModule.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { CsvModule } from "../controllers/connector/csv/CsvModule";
+import { ExcelModule } from "../controllers/connector/excel/ExcelModule";
+import { GoogleSlidesModule } from "../controllers/connector/google_slides/GoogleSlidesModule";
+import { HancellModule } from "../controllers/connector/hancell/HancellModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    CsvModule,
+    LlmModule,
+    ExcelModule,
+    HancellModule,
+    GoogleSlidesModule,
+  ],
+})
+export class DataAnalyticsModule {}

--- a/src/swaggers/EducationModule.ts
+++ b/src/swaggers/EducationModule.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { ArxivSearchModule } from "../controllers/connector/arxiv_search/ArxivSearchModule";
+import { GoogleScholarModule } from "../controllers/connector/google_scholar/GoolgeScholarModule";
+import { NotionModule } from "../controllers/connector/notion/NotionModule";
+
+/**
+ * 교육
+ */
+@Module({
+  imports: [ArxivSearchModule, GoogleScholarModule, NotionModule],
+})
+export class EducationModule {}

--- a/src/swaggers/EntertainmentModule.ts
+++ b/src/swaggers/EntertainmentModule.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { ChatbotModule } from "../controllers/connector/chatbot/ChatbotModule";
+import { KakaoTalkModule } from "../controllers/connector/kakao_talk/KakaoTalkModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { YoutubeSearchModule } from "../controllers/connector/youtube_search/YoutubeSearchModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    YoutubeSearchModule,
+    LlmModule,
+    ChatbotModule,
+    KakaoTalkModule,
+  ],
+})
+export class EntertainmentModule {}

--- a/src/swaggers/GraphicDesignModule.ts
+++ b/src/swaggers/GraphicDesignModule.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { DallE3Module } from "../controllers/connector/dall_e_3/DallE3Module";
+import { FigmaModule } from "../controllers/connector/figma/FigmaModule";
+import { StableDiffusionBetaModule } from "../controllers/connector/stable_diffustion_beta/StableDiffusionBetaModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    FigmaModule,
+    StableDiffusionBetaModule,
+    DallE3Module,
+  ],
+})
+export class GraphicDesignModule {}

--- a/src/swaggers/ITDevelopmentModule.ts
+++ b/src/swaggers/ITDevelopmentModule.ts
@@ -1,0 +1,41 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { ArxivSearchModule } from "../controllers/connector/arxiv_search/ArxivSearchModule";
+import { CsvModule } from "../controllers/connector/csv/CsvModule";
+import { ExcelModule } from "../controllers/connector/excel/ExcelModule";
+import { FigmaModule } from "../controllers/connector/figma/FigmaModule";
+import { GmailModule } from "../controllers/connector/gmail/GmailModule";
+import { GoogleDocsModule } from "../controllers/connector/google-docs/GoogleDocsModule";
+import { GoogleSheetModule } from "../controllers/connector/google-sheet/GoogleSheetModule";
+import { GoogleCalendarModule } from "../controllers/connector/google_calendar/GoogleCalendarModule";
+import { GoogleDriveModule } from "../controllers/connector/google_drive/GoogleDriveModule";
+import { GoogleScholarModule } from "../controllers/connector/google_scholar/GoolgeScholarModule";
+import { GoogleSlidesModule } from "../controllers/connector/google_slides/GoogleSlidesModule";
+import { HwpModule } from "../controllers/connector/hwp/HwpModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { NotionModule } from "../controllers/connector/notion/NotionModule";
+
+/**
+ * IT/개발
+ */
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    ArxivSearchModule,
+    GoogleScholarModule,
+    CsvModule,
+    NotionModule,
+    LlmModule,
+    HwpModule,
+    ExcelModule,
+    GoogleDocsModule,
+    GoogleSheetModule,
+    GoogleCalendarModule,
+    GoogleDriveModule,
+    GmailModule,
+    FigmaModule,
+    GoogleSlidesModule,
+  ],
+})
+export class ITDevelopmentModule {}

--- a/src/swaggers/ImageVideoModule.ts
+++ b/src/swaggers/ImageVideoModule.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { DallE3Module } from "../controllers/connector/dall_e_3/DallE3Module";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { StableDiffusionBetaModule } from "../controllers/connector/stable_diffustion_beta/StableDiffusionBetaModule";
+import { YoutubeSearchModule } from "../controllers/connector/youtube_search/YoutubeSearchModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    YoutubeSearchModule,
+    LlmModule,
+    StableDiffusionBetaModule,
+    DallE3Module,
+  ],
+})
+export class ImageVideoModule {}

--- a/src/swaggers/LifeStyleModule.ts
+++ b/src/swaggers/LifeStyleModule.ts
@@ -1,0 +1,25 @@
+import { Module } from "@nestjs/common";
+import { ChatbotModule } from "../controllers/connector/chatbot/ChatbotModule";
+import { DaumModule } from "../controllers/connector/daum/DaumModule";
+import { GoogleCalendarModule } from "../controllers/connector/google_calendar/GoogleCalendarModule";
+import { GoogleShoppingModule } from "../controllers/connector/google_shopping/GoogleShoppingModule";
+import { KakaoMapModule } from "../controllers/connector/kakao_map/KakaoMapModule";
+import { KakaoNaviModule } from "../controllers/connector/kakao_navi/KakaoNaviModule";
+import { KakaoTalkModule } from "../controllers/connector/kakao_talk/KakaoTalkModule";
+import { NaverModule } from "../controllers/connector/naver/NaverModule";
+import { YoutubeSearchModule } from "../controllers/connector/youtube_search/YoutubeSearchModule";
+
+@Module({
+  imports: [
+    DaumModule,
+    NaverModule,
+    YoutubeSearchModule,
+    GoogleCalendarModule,
+    ChatbotModule,
+    KakaoTalkModule,
+    KakaoMapModule,
+    KakaoNaviModule,
+    GoogleShoppingModule,
+  ],
+})
+export class LifeStyleModule {}

--- a/src/swaggers/MarketingModule.ts
+++ b/src/swaggers/MarketingModule.ts
@@ -1,0 +1,19 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { DaumModule } from "../controllers/connector/daum/DaumModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { NaverModule } from "../controllers/connector/naver/NaverModule";
+
+/**
+ * 마케팅/광고
+ */
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    DaumModule,
+    NaverModule,
+    LlmModule,
+  ],
+})
+export class MarketingModule {}

--- a/src/swaggers/MusicModule.ts
+++ b/src/swaggers/MusicModule.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common";
+import { YoutubeSearchModule } from "../controllers/connector/youtube_search/YoutubeSearchModule";
+
+@Module({
+  imports: [YoutubeSearchModule],
+})
+export class MusicModule {}

--- a/src/swaggers/NewsMediaModule.ts
+++ b/src/swaggers/NewsMediaModule.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+
+@Module({
+  imports: [LoggerModule.forRoot({ ...pinoLoggerParams }), LlmModule],
+})
+export class NewsMediaModule {}

--- a/src/swaggers/ProductivityModule.ts
+++ b/src/swaggers/ProductivityModule.ts
@@ -1,0 +1,46 @@
+import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { pinoLoggerParams } from "../common/logger/logger";
+import { CsvModule } from "../controllers/connector/csv/CsvModule";
+import { DallE3Module } from "../controllers/connector/dall_e_3/DallE3Module";
+import { DaumModule } from "../controllers/connector/daum/DaumModule";
+import { ExcelModule } from "../controllers/connector/excel/ExcelModule";
+import { FigmaModule } from "../controllers/connector/figma/FigmaModule";
+import { GmailModule } from "../controllers/connector/gmail/GmailModule";
+import { GoogleDocsModule } from "../controllers/connector/google-docs/GoogleDocsModule";
+import { GoogleSheetModule } from "../controllers/connector/google-sheet/GoogleSheetModule";
+import { GoogleCalendarModule } from "../controllers/connector/google_calendar/GoogleCalendarModule";
+import { GoogleDriveModule } from "../controllers/connector/google_drive/GoogleDriveModule";
+import { GoogleSlidesModule } from "../controllers/connector/google_slides/GoogleSlidesModule";
+import { HancellModule } from "../controllers/connector/hancell/HancellModule";
+import { HwpModule } from "../controllers/connector/hwp/HwpModule";
+import { KakaoTalkModule } from "../controllers/connector/kakao_talk/KakaoTalkModule";
+import { LlmModule } from "../controllers/connector/llm/LlmModule";
+import { NaverModule } from "../controllers/connector/naver/NaverModule";
+import { NotionModule } from "../controllers/connector/notion/NotionModule";
+import { StableDiffusionBetaModule } from "../controllers/connector/stable_diffustion_beta/StableDiffusionBetaModule";
+
+@Module({
+  imports: [
+    LoggerModule.forRoot({ ...pinoLoggerParams }),
+    DaumModule,
+    NaverModule,
+    CsvModule,
+    NotionModule,
+    LlmModule,
+    HwpModule,
+    ExcelModule,
+    GoogleDocsModule,
+    GoogleSheetModule,
+    GoogleCalendarModule,
+    GoogleDriveModule,
+    GmailModule,
+    FigmaModule,
+    HancellModule,
+    KakaoTalkModule,
+    GoogleSlidesModule,
+    StableDiffusionBetaModule,
+    DallE3Module,
+  ],
+})
+export class ProductivityModule {}

--- a/src/swaggers/ResearchModule.ts
+++ b/src/swaggers/ResearchModule.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { ArxivSearchModule } from "../controllers/connector/arxiv_search/ArxivSearchModule";
+import { GoogleScholarModule } from "../controllers/connector/google_scholar/GoolgeScholarModule";
+
+/**
+ * 학술/연구
+ */
+@Module({
+  imports: [ArxivSearchModule, GoogleScholarModule],
+})
+export class ResearchModule {}

--- a/src/swaggers/TravelModule.ts
+++ b/src/swaggers/TravelModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { KakaoMapModule } from "../controllers/connector/kakao_map/KakaoMapModule";
+import { KakaoNaviModule } from "../controllers/connector/kakao_navi/KakaoNaviModule";
+
+@Module({
+  imports: [KakaoMapModule, KakaoNaviModule],
+})
+export class TravelModule {}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
 out/swagger/*.json
+out/swagger/categories/*.swagger.json

--- a/website/build/swagger.js
+++ b/website/build/swagger.js
@@ -6,10 +6,24 @@ const main = () => {
     stdio: "inherit",
     cwd: `${__dirname}/../..`,
   });
-  for (const name of ["swagger", "openai-keyword", "openai-positional", "migrate", "version"])
+  for (const name of [
+    "swagger",
+    "openai-keyword",
+    "openai-positional",
+    "migrate",
+    "version",
+  ])
     fs.copyFileSync(
       `${__dirname}/../../packages/api/${name}.json`,
       `${__dirname}/../out/swagger/${name}.json`,
     );
+
+  fs.cpSync(
+    `${__dirname}/../../packages/api/categories`,
+    `${__dirname}/../out/swagger/categories`,
+    {
+      recursive: true,
+    },
+  );
 };
 main();


### PR DESCRIPTION
스웨거를 카테고리 단위로 분리했습니다.
노션에서는 카테고리가 커넥터 단위라서, 일단 커넥터 단위로는 안했습니다.
예를 들어 구글 커넥터 2개가 각각 A랑 B에 속하면 A, B 스웨거 모두에 구글을 넣어주었습니다.
단, 공공데이터는 커넥터끼리 카테고리가 너무 달라서 일단 공공데이터끼리 카테고리로 묶었습니다.

- `version.yml` 실행.
- website/package.json에서 npm run build를 실행하면 `node build/swagger.js`를 실행
- `swagger.js`에서는 root folder의 `npm run build:swagger`를 실행
- 전체 스웨거와 카테고리별 스웨거가 빌드됨.
- 스웨거들을 Web/out/swagger로 복사.