### PR TITLE
fix: fix prerequiste and retry function again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@nestjs/testing": "^10.3.9",
         "@notionhq/client": "^2.2.15",
         "@samchon/openapi": "^0.4.2",
-        "@wrtnio/decorators": "^1.4.6",
+        "@wrtnio/decorators": "^1.4.9",
         "@wrtnio/openai-function-schema": "^0.2.0",
         "atob": "^2.1.2",
         "aws-sdk": "^2.1546.0",
@@ -3590,9 +3590,9 @@
       }
     },
     "node_modules/@wrtnio/decorators": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@wrtnio/decorators/-/decorators-1.4.6.tgz",
-      "integrity": "sha512-b9xRbGNdOzK3/mHVc3d1r5cuJZuU/EKBPw1xPYOLdMezHbKb9rbCA8SN+fKEAh1daKjoTiPD2f1+OMHxBe0WTg==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@wrtnio/decorators/-/decorators-1.4.9.tgz",
+      "integrity": "sha512-/+iic+K/t30Emym5+0fDPhBgQuFMpXU3R3PEf45JuZySJeZF34klT+Q+tx5Oa1UPwxgnl1qDzr3AbBwD4UG4hg==",
       "license": "MIT",
       "peerDependencies": {
         "@nestia/core": ">=3.2.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@nestjs/testing": "^10.3.9",
     "@notionhq/client": "^2.2.15",
     "@samchon/openapi": "^0.4.2",
-    "@wrtnio/decorators": "^1.4.6",
+    "@wrtnio/decorators": "^1.4.9",
     "@wrtnio/openai-function-schema": "^0.2.0",
     "atob": "^2.1.2",
     "aws-sdk": "^2.1546.0",

--- a/src/api/structures/connector/google_ads/IGoogleAds.ts
+++ b/src/api/structures/connector/google_ads/IGoogleAds.ts
@@ -1,4 +1,4 @@
-import type { JMESPath, Prerequisite } from "@wrtnio/decorators";
+import type { JMESPath, Placeholder, Prerequisite } from "@wrtnio/decorators";
 import type { tags } from "typia";
 import { DeepStrictMerge } from "../../../../utils/types/DeepStrictMerge";
 import { ICommon } from "../common/ISecretValue";
@@ -277,8 +277,12 @@ export namespace IGoogleAds {
   export type AdGroupCriterion = {
     /**
      * @title 광고 그룹 표준 리소스 이름
+     *
+     * `customers/${number}/adGroupCriteria/number~${number}` 형식
      */
-    resourceName: `customers/${CustomerClient["id"]}/adGroupCriteria/${AdGroup["id"]}~${AdGroupCriterion["criterionId"]}`;
+    resourceName: string &
+      tags.Pattern<"(customers\\/(.*)\\/adGroupCriteria\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?~[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"customers/1/adGroupCriteria/1">;
 
     /**
      * @title 타입
@@ -331,10 +335,10 @@ export namespace IGoogleAds {
     adGroupResourceName: AdGroup["resourceName"] &
       Prerequisite<{
         method: "post";
-        path: "connector/google-ads/get-ads";
+        path: "connector/google-ads/get-ad-groups";
         jmesPath: JMESPath<
-          IGetAdGroupAdOutput,
-          "[].{value:resourceName, label:resourceName}"
+          IGetAdGroupOutput,
+          "[].adGroup.{value:resourceName, label:resourceName}"
         >;
       }>;
   }
@@ -357,9 +361,13 @@ export namespace IGoogleAds {
     id: `${number}`;
 
     /**
+     * `customers/${number}/adGroups/${number}` 형식
+     *
      * @title 광고 그룹 리소스 명
      */
-    resourceName: `customers/${number}/adGroups/${number}`;
+    resourceName: string &
+      tags.Pattern<"(customers\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\/adGroups\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"customers/1/adGroups/1">;
 
     /**
      * @title 광고 그룹 이름
@@ -410,9 +418,13 @@ export namespace IGoogleAds {
 
   export interface AdGroupAd {
     /**
+     * `customers/${number}/adGroupAds/${number}~${number}` 형식
+     *
      * @title 광고 그룹 광고의 리소스 명
      */
-    resourceName: `customers/${number}/adGroupAds/${number}~${number}`;
+    resourceName: string &
+      tags.Pattern<"(customers\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\/adGroupAds\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?~[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"customers/1/adGroupAds/1~1">;
 
     /**
      * @title 광고 심사 및 정책에 대한 평가 내역
@@ -764,7 +776,9 @@ export namespace IGoogleAds {
     /**
      * @title 캠페인 리소스 명
      */
-    resourceName: `customers/${number}/campaigns/${number}`;
+    resourceName: string &
+      tags.Pattern<"(customers\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\/campaigns\\/[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"customers/1/campaigns/1">;
 
     /**
      * @title 캠페인 상태
@@ -798,7 +812,9 @@ export namespace IGoogleAds {
     /**
      * @title 캠페인 아이디
      */
-    id: `${number}`;
+    id: string &
+      tags.Pattern<"([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"1">;
 
     /**
      * @title 캠페인 시작 일자
@@ -936,15 +952,12 @@ export namespace IGoogleAds {
       Prerequisite<{
         method: "post";
         path: "connector/google-ads/get-customers";
-        jmesPath: JMESPath<
-          IGetCustomerOutput,
-          "[].{value:id, label:descriptiveName}"
-        >;
+        jmesPath: JMESPath<IGetCustomerOutput, "[].{value:id, label:id}">;
       }>;
   }
 
   export interface RESOURCE_EXHAUSTED_ERROR {
-    message: "Too many requests. Retry in 7 seconds.";
+    message: string;
     details: {
       quotaErrorDetails: {
         rateScope: string;
@@ -955,7 +968,8 @@ export namespace IGoogleAds {
   }
 
   export interface Customer {
-    id: `${number}`;
+    id: string;
+
     resourceName: `customers/${number}`;
   }
 
@@ -964,7 +978,9 @@ export namespace IGoogleAds {
      * @title 고객 아이디
      * @description 고객마다 고유한 값을 가지고 있다.
      */
-    id: `${number}`;
+    id: string &
+      tags.Pattern<"([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"1">;
 
     /**
      * @title 고객 리소스 명

--- a/src/api/structures/connector/kakao_navi/IKakaoNavi.ts
+++ b/src/api/structures/connector/kakao_navi/IKakaoNavi.ts
@@ -16,13 +16,17 @@ export namespace IKakaoNavi {
      * @title 출발지
      * @description X좌표,Y좌표 형식의 경도, 위도 값
      */
-    origin: `${number},${number}` & Placeholder<"127.111202,37.394912">;
+    origin: string &
+      tags.Pattern<"([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?,[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"127.111202,37.394912">;
 
     /**
      * @title 목적지
      * @description X좌표,Y좌표 형식의 경도, 위도 값
      */
-    destination: `${number},${number}` & Placeholder<"127.111202,37.394912">;
+    destination: string &
+      tags.Pattern<"([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?,[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"> &
+      Placeholder<"127.111202,37.394912">;
   }
 
   /**

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -68,9 +68,7 @@ export function retry<T extends any[], ReturnType>(
                 }),
             );
 
-            await new Promise<void>((res) => {
-              setTimeout(() => res(), maxDelay * 1000);
-            });
+            await new Promise<void>((res) => setTimeout(res, maxDelay * 1000));
           }
         }
 


### PR DESCRIPTION
- 템플릿 리터럴 타입을 모두 tags.Pattern과 Primitive 타입의 인터섹션으로 재정의
    - Swagger 상에 "0"을 키로 갖는 객체타입으로 표현되는 문제를 해결하기 위함인데, Typescript Compiler API 상에서 템플릿 리터럴 타입의 인터섹션이 객체로 표현되는 문제를 회피하기 위함
- retry 함수 수정
    - 로컬에서 구글에 수십번 요청을 날려(!?) 똑같은 장애 상황을 재현한 다음 테스트를 하였음.