### PR TITLE
feat: Add figma oauth2

### DIFF
--- a/src/ConnectorGlobal.ts
+++ b/src/ConnectorGlobal.ts
@@ -53,8 +53,11 @@ export namespace ConnectorGlobal {
     TYPEFORM_PERSONAL_ACCESS_KEY: string;
 
     // FIGMA
-    FIGMA_TEST_SECRET: string;
     FIGMA_TEST_FILE_KEY: string;
+
+    FIGMA_CLIENT_ID: string;
+    FIGMA_CLIENT_SECRET: string;
+    FIGMA_TEST_SECRET: string;
 
     // ZOOM
     ZOOM_TEST_REFRESH_TOKEN: string;

--- a/src/api/structures/connector/figma/IFigma.ts
+++ b/src/api/structures/connector/figma/IFigma.ts
@@ -12,13 +12,19 @@ import { tags } from "typia";
 import { ICommon } from "../common/ISecretValue";
 
 export namespace IFigma {
+  export type Secret = ICommon.ISecret<
+    "figma",
+    [
+      "files:read,file_variables:read,file_variables:write,file_comments:write,file_dev_resources:read,file_dev_resources:write,library_analytics:read,webhooks:write",
+    ]
+  >;
+
   /**
    * 피그마 특정 프레임으로부터 파일을 조회하는 DTO.
    *
    * 한 번에 하나의 프레임으로부터 파일을 읽을 수 있다.
    */
-  export interface IReadFileInput
-    extends ICommon.ISecret<"figma", ["files:read"]> {
+  export interface IReadFileInput extends IFigma.Secret {
     /**
      * 파일의 키를 의미합니다.
      *
@@ -193,7 +199,7 @@ export namespace IFigma {
    * 한 번의 하나의 댓글을 작성할 수 있으며, 좌표 값이나 노드, 또는 부모 댓글(root comment) 이용해 댓글을 작성할 수 있다.
    */
   export interface IAddCommentInput
-    extends ICommon.ISecret<"figma", ["file_comments:write"]>,
+    extends IFigma.Secret,
       PostCommentRequestBody {
     /**
      * 파일의 키를 의미합니다.
@@ -208,7 +214,7 @@ export namespace IFigma {
    * 한 번에 하나의 프레임으로부터 댓글을 읽을 수 있다.
    */
   export interface IReadCommentInput
-    extends ICommon.ISecret<"figma", ["files:read"]>,
+    extends IFigma.Secret,
       GetCommentsQueryParams {
     /**
      * 파일의 키를 의미합니다.

--- a/src/api/structures/connector/figma/IFigma.ts
+++ b/src/api/structures/connector/figma/IFigma.ts
@@ -233,4 +233,44 @@ export namespace IFigma {
    * 읽어온 피그마 댓글의 정보에 해당하는 DTO.
    */
   export type IReadCommentOutput = GetCommentsResponse;
+
+  /**
+   * @title 프로젝트 조회 조건
+   */
+  export interface IGetProjectInput extends IFigma.Secret {
+    /**
+     * @title 팀 아이디
+     *
+     * `https://www.figma.com/files/team` 링크 접속 시 `team` 키워드 뒤에 붙어 있는 문자열을 의미한다.
+     *
+     * 팀 아이디는 숫자 형식이며, 팀 안에 여러 개의 프로젝트들이 존재할 수 있다.
+     */
+    teamId: string;
+  }
+
+  export interface IGetProejctOutput {
+    /**
+     * @title 팀 이름
+     */
+    name: string;
+
+    /**
+     * @title 프로젝트 목록
+     *
+     * 팀에 속해있는 프로젝트들의 목록을 의미합니다.
+     */
+    projects: Array<Project>;
+  }
+
+  export interface Project {
+    /**
+     * @title 프로젝트 아이디
+     */
+    id: string;
+
+    /**
+     * @title 프로젝트 이름
+     */
+    name: string;
+  }
 }

--- a/src/controllers/connector/figma/FigmaController.ts
+++ b/src/controllers/connector/figma/FigmaController.ts
@@ -73,4 +73,26 @@ export class FigmaController {
   ): Promise<IFigma.IReadCommentOutput> {
     return retry(() => this.figmaProvider.getComments(input))();
   }
+
+  /**
+   * 팀 내의 프로젝트를 조회합니다.
+   * 인자로는 teamId를 받아야 하는데, 이 프로퍼티는 팀 아이디를 의미하며 figma의 URL 경로를 보고 파악할 수 있습니다.
+   * `https://www.figma.com/files/team` 링크 접속 시 `team` 키워드 뒤에 자동으로 숫자가 붙게 되는데 이것이 팀의 아이디입니다.
+   * 유저는 여러가지 팀에 속할 수 있으므로, 만일 이 프로젝트들에 대한 조회를 자동화하고 싶지 않다면 다른 팀 아이디를 가져와야 합니다.
+   *
+   * @summary 팀 내 프로젝트 조회
+   * @param input 프로젝트 조회 조건
+   * @tag figma
+   *
+   * @returns 프로젝트 목록
+   */
+  @RouteIcon(
+    "https://ecosystem-connector.s3.ap-northeast-2.amazonaws.com/icon/figma.svg",
+  )
+  @core.TypedRoute.Post("get-projects")
+  async getProjects(
+    @core.TypedBody() input: IFigma.IGetProjectInput,
+  ): Promise<IFigma.IGetProejctOutput> {
+    return retry(() => this.figmaProvider.getProjects(input))();
+  }
 }

--- a/src/providers/figma/FigmaProvider.ts
+++ b/src/providers/figma/FigmaProvider.ts
@@ -79,6 +79,21 @@ export class FigmaProvider {
     }
   }
 
+  async getProjects(
+    input: IFigma.IGetProjectInput,
+  ): Promise<IFigma.IGetProejctOutput> {
+    const url = `https://api.figma.com/v1/teams/${input.teamId}/projects`;
+    const accessToken = await this.refresh(input.secretKey);
+
+    const res = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    return res.data;
+  }
+
   private async refresh(refreshToken: string): Promise<string> {
     const url = `https://www.figma.com/api/oauth/refresh`;
     const res = await axios.post(

--- a/test/features/api/connector/figma/test_api_connector_figma.ts
+++ b/test/features/api/connector/figma/test_api_connector_figma.ts
@@ -66,3 +66,18 @@ export const test_api_connector_figma_add_comment = async (
     readCommentEvent.comments.find((el) => el.id === addCommentEvent.id)!,
   );
 };
+
+export const test_api_connector_figma_get_projects = async (
+  connection: CApi.IConnection,
+) => {
+  /**
+   * add comment API
+   */
+  const projects =
+    await CApi.functional.connector.figma.get_projects.getProjects(connection, {
+      secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+      teamId: "1379663189749043465",
+    });
+
+  typia.assertEquals(projects);
+};


### PR DESCRIPTION
기존의 피그마는 개인의 토큰을 이용한 방식이었는데, 이번에는 OAuth2로 바꿨습니다.
이 편이 더 가입하기 편할 거란 판단.