### PR TITLE
피그마 통계 조회해보기

### DIFF
--- a/src/api/structures/connector/figma/IFigma.ts
+++ b/src/api/structures/connector/figma/IFigma.ts
@@ -5,6 +5,7 @@ import {
   GetCommentsResponse,
   PostCommentRequestBody,
   PostCommentResponse,
+  Comment,
   Style,
 } from "@figma/rest-api-spec";
 import { tags } from "typia";
@@ -248,6 +249,11 @@ export namespace IFigma {
     teamId: string;
   }
 
+  export interface IGetProjectStatisticsInput
+    extends IFigma.Secret,
+      Pick<IFigma.IReadCommentInput, "as_md">,
+      IFigma.IGetProjectInput {}
+
   export interface IGetProejctOutput {
     /**
      * @title 팀 이름
@@ -285,10 +291,10 @@ export namespace IFigma {
      *
      * @title 캔버스 목록
      */
-    files: File[];
+    files: Canvas[];
   }
 
-  export interface File {
+  export interface Canvas {
     /**
      * 파일을 고유하게 식별할 수 있는 키입니다.
      * 여기서 말하는 파일은 프로젝트에서 관리하고 있는 캔버스들을 의미합니다.
@@ -321,5 +327,34 @@ export namespace IFigma {
      * @title 마지막 수정 시간
      */
     last_modified: string & tags.Format<"date-time">;
+  }
+
+  export interface CanvasStatistics extends Canvas {
+    /**
+     * @title 캔버스 내 댓글 목록
+     */
+    comments: Comment[];
+
+    /**
+     * @title 캔버스 내 댓글에 대한 통계
+     */
+    statistics: {
+      /**
+       * @title 토론에 참여한 사람 명단
+       */
+      users: string[];
+
+      /**
+       * @title 각 사람 별 댓글 수
+       */
+      counts: Record<string, number>;
+    };
+  }
+
+  export interface IGetStatisticsOutput extends Pick<Project, "id" | "name"> {
+    /**
+     * @title 프로젝트 내 캔버스 별 통계
+     */
+    canvasList: CanvasStatistics[];
   }
 }

--- a/src/api/structures/connector/figma/IFigma.ts
+++ b/src/api/structures/connector/figma/IFigma.ts
@@ -273,4 +273,53 @@ export namespace IFigma {
      */
     name: string;
   }
+
+  export interface IGetProjectFileOutput {
+    /**
+     * @title 프로젝트 이름
+     */
+    name: Project["name"];
+
+    /**
+     * 프로젝트에서 관리하고 있는 캔버스의 목록입니다.
+     *
+     * @title 캔버스 목록
+     */
+    files: File[];
+  }
+
+  export interface File {
+    /**
+     * 파일을 고유하게 식별할 수 있는 키입니다.
+     * 여기서 말하는 파일은 프로젝트에서 관리하고 있는 캔버스들을 의미합니다.
+     * 피그마에서는 캔버스를 포함한, 캔버스의 자식 컴포넌트 요소 모두 다 파일이라고 부르기 때문에 용어의 혼동에 주의해야 합니다.
+     *
+     * @title 캔버스 키
+     */
+    key: string;
+
+    /**
+     * 파일을 식별할 수 있도록 사용자가 붙여 놓은 이름을 의미합니다.
+     * 여기서 말하는 파일은 프로젝트에서 관리하고 있는 캔버스들을 의미합니다.
+     * 피그마에서는 캔버스를 포함한, 캔버스의 자식 컴포넌트 요소 모두 다 파일이라고 부르기 때문에 용어의 혼동에 주의해야 합니다.
+     *
+     * @title 캔버스 이름
+     */
+    name: string;
+
+    /**
+     * 섬네일 이미지로, 이 캔버스의 메인이 되는 화면을 스크린샷처럼 제공합니다.
+     * 하지만, 이 섬네일을 링크로 저장해서 사용하려는 경우에는 이 이미지가 일정 시간동안만 제공되는 점에 주의해야 합니다.
+     *
+     * @title 섬네일
+     */
+    thumbnail_url: string &
+      tags.Format<"uri"> &
+      tags.ContentMediaType<"image/*">;
+
+    /**
+     * @title 마지막 수정 시간
+     */
+    last_modified: string & tags.Format<"date-time">;
+  }
 }

--- a/src/api/structures/connector/figma/IFigma.ts
+++ b/src/api/structures/connector/figma/IFigma.ts
@@ -324,6 +324,9 @@ export namespace IFigma {
       tags.ContentMediaType<"image/*">;
 
     /**
+     * 해당 캔버스의 마지막 수정 시간을 의미한다.
+     * 이를 기준으로 가장 최근에 변경점이 있거나 소통이 오가는 등 유지관리되는 캔버스를 구별할 수도 있을 것이다.
+     *
      * @title 마지막 수정 시간
      */
     last_modified: string & tags.Format<"date-time">;

--- a/src/controllers/connector/figma/FigmaController.ts
+++ b/src/controllers/connector/figma/FigmaController.ts
@@ -75,8 +75,12 @@ export class FigmaController {
   }
 
   /**
-   * 특정 프로젝트의 모든 파일을 가져옵니다.
+   * 특정 프로젝트의 모든 캔버스를 가져옵니다.
+   * 캔버스는 특정 팀에서 관리하고 있는 피그마 파일들을 의미합니다.
+   * 이 커넥터를 통해 사용자는 자신의 피그마 팀 내에 어떤 캔버스들이 관리되고 있는지 캔버스의 이름과 섬네일 링크를 받아 볼 수 있습니다.
    *
+   * @summary 팀 내 캔버스 조회
+   * @tag figma
    * @param projectId 조회할 프로젝트의 아이디
    * @param input 프로젝트 조회 조건
    * @returns 프로젝트의 모든 파일
@@ -84,8 +88,8 @@ export class FigmaController {
   @core.TypedRoute.Post("projects/:id/get-files")
   async getProjectFiles(
     @Prerequisite({
-      neighbor: () => 1,
-      jmesPath: "",
+      neighbor: () => FigmaController.prototype.getProjects,
+      jmesPath: "proejcts[].{value:id, label:name}",
     })
     @TypedParam("id")
     projectId: string,

--- a/src/controllers/connector/figma/FigmaController.ts
+++ b/src/controllers/connector/figma/FigmaController.ts
@@ -98,8 +98,30 @@ export class FigmaController {
     projectId: string,
     @TypedBody()
     input: IFigma.Secret,
-  ) {
-    return retry(() => this.figmaProvider.getProjectFiles(projectId, input))();
+  ): Promise<IFigma.IGetProjectFileOutput> {
+    return retry(() => this.figmaProvider.getProjectCanvas(projectId, input))();
+  }
+
+  /**
+   * 팀 단위의 통계를 조회합니다.
+   *
+   * @summary 팀 단위 피그마 통계 조회
+   * @param input 팀 단위 통계 조회 조건
+   * @tag figma
+   *
+   * @returns 팀의 통계 조회 결과
+   */
+  @Standalone()
+  @RouteIcon(
+    "https://ecosystem-connector.s3.ap-northeast-2.amazonaws.com/icon/figma.svg",
+  )
+  @core.TypedRoute.Post("get-statistics")
+  async getStatistics(
+    @TypedBody()
+    input: IFigma.IGetProjectStatisticsInput,
+  ): Promise<IFigma.IGetStatisticsOutput[]> {
+    const team = await this.figmaProvider.getProjects(input);
+    return this.figmaProvider.getStatistics(input, team);
   }
 
   /**

--- a/src/controllers/connector/figma/FigmaController.ts
+++ b/src/controllers/connector/figma/FigmaController.ts
@@ -1,6 +1,6 @@
 import core, { TypedBody, TypedParam } from "@nestia/core";
 import { Controller } from "@nestjs/common";
-import { Prerequisite, RouteIcon } from "@wrtnio/decorators";
+import { Prerequisite, RouteIcon, Standalone } from "@wrtnio/decorators";
 
 import { IFigma } from "@wrtn/connector-api/lib/structures/connector/figma/IFigma";
 
@@ -85,8 +85,11 @@ export class FigmaController {
    * @param input 프로젝트 조회 조건
    * @returns 프로젝트의 모든 파일
    */
-  @core.TypedRoute.Post("projects/:id/get-files")
-  async getProjectFiles(
+  @RouteIcon(
+    "https://ecosystem-connector.s3.ap-northeast-2.amazonaws.com/icon/figma.svg",
+  )
+  @core.TypedRoute.Post("projects/:id/get-canvas")
+  async getProjectCanvas(
     @Prerequisite({
       neighbor: () => FigmaController.prototype.getProjects,
       jmesPath: "proejcts[].{value:id, label:name}",
@@ -111,6 +114,7 @@ export class FigmaController {
    *
    * @returns 프로젝트 목록
    */
+  @Standalone()
   @RouteIcon(
     "https://ecosystem-connector.s3.ap-northeast-2.amazonaws.com/icon/figma.svg",
   )

--- a/src/controllers/connector/figma/FigmaController.ts
+++ b/src/controllers/connector/figma/FigmaController.ts
@@ -1,6 +1,6 @@
-import core from "@nestia/core";
+import core, { TypedBody, TypedParam } from "@nestia/core";
 import { Controller } from "@nestjs/common";
-import { RouteIcon } from "@wrtnio/decorators";
+import { Prerequisite, RouteIcon } from "@wrtnio/decorators";
 
 import { IFigma } from "@wrtn/connector-api/lib/structures/connector/figma/IFigma";
 
@@ -72,6 +72,27 @@ export class FigmaController {
     @core.TypedBody() input: IFigma.IReadCommentInput,
   ): Promise<IFigma.IReadCommentOutput> {
     return retry(() => this.figmaProvider.getComments(input))();
+  }
+
+  /**
+   * 특정 프로젝트의 모든 파일을 가져옵니다.
+   *
+   * @param projectId 조회할 프로젝트의 아이디
+   * @param input 프로젝트 조회 조건
+   * @returns 프로젝트의 모든 파일
+   */
+  @core.TypedRoute.Post("projects/:id/get-files")
+  async getProjectFiles(
+    @Prerequisite({
+      neighbor: () => 1,
+      jmesPath: "",
+    })
+    @TypedParam("id")
+    projectId: string,
+    @TypedBody()
+    input: IFigma.Secret,
+  ) {
+    return retry(() => this.figmaProvider.getProjectFiles(projectId, input))();
   }
 
   /**

--- a/src/providers/figma/FigmaProvider.ts
+++ b/src/providers/figma/FigmaProvider.ts
@@ -73,16 +73,34 @@ export class FigmaProvider {
         },
       );
       return res.data;
-    } catch (err) {
-      console.log("err", err);
-      throw err;
+    } catch (error) {
+      console.error(JSON.stringify(error));
+      throw error;
+    }
+  }
+
+  async getProjectFiles(projectId: string, input: IFigma.Secret) {
+    try {
+      const url = `https://api.figma.com/v1/projects/${projectId}/files`;
+      const accessToken = await this.refresh(input.secretKey);
+
+      const res = await axios.get(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      return res.data;
+    } catch (error) {
+      console.error(JSON.stringify(error));
+      throw error;
     }
   }
 
   async getProjects(
     input: IFigma.IGetProjectInput,
   ): Promise<IFigma.IGetProejctOutput> {
-    const url = `https://api.figma.com/v1/teams/${input.teamId}/projects`;
+    const url = `https://api.figma.com/v1/teams/${input.teamId}/projects?branch_data=true`;
     const accessToken = await this.refresh(input.secretKey);
 
     const res = await axios.get(url, {

--- a/test/features/api/connector/figma/test_api_connector_figma.ts
+++ b/test/features/api/connector/figma/test_api_connector_figma.ts
@@ -97,3 +97,20 @@ export const test_api_connector_figma_get_project_files = async (
     typia.assert(files);
   }
 };
+
+export const test_api_connector_get_statistics = async (
+  connection: CApi.IConnection,
+) => {
+  const res =
+    await CApi.functional.connector.figma.get_statistics.getStatistics(
+      connection,
+      {
+        as_md: true,
+        teamId: "1379663189749043465",
+        secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+      },
+    );
+
+  console.log(JSON.stringify(res, null, 2));
+  typia.assert(res);
+};

--- a/test/features/api/connector/figma/test_api_connector_figma.ts
+++ b/test/features/api/connector/figma/test_api_connector_figma.ts
@@ -70,14 +70,33 @@ export const test_api_connector_figma_add_comment = async (
 export const test_api_connector_figma_get_projects = async (
   connection: CApi.IConnection,
 ) => {
-  /**
-   * add comment API
-   */
-  const projects =
-    await CApi.functional.connector.figma.get_projects.getProjects(connection, {
+  const team = await CApi.functional.connector.figma.get_projects.getProjects(
+    connection,
+    {
       secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
       teamId: "1379663189749043465",
-    });
+    },
+  );
 
-  typia.assertEquals(projects);
+  typia.assertEquals(team);
+  return team;
+};
+
+export const test_api_connector_figma_get_project_files = async (
+  connection: CApi.IConnection,
+) => {
+  const team = await test_api_connector_figma_get_projects(connection);
+
+  for await (const project of team.projects) {
+    const files =
+      await CApi.functional.connector.figma.projects.get_files.getProjectFiles(
+        connection,
+        project.id,
+        {
+          secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+        },
+      );
+
+    typia.assert(files);
+  }
 };

--- a/test/features/api/connector/figma/test_api_connector_figma.ts
+++ b/test/features/api/connector/figma/test_api_connector_figma.ts
@@ -111,6 +111,5 @@ export const test_api_connector_get_statistics = async (
       },
     );
 
-  console.log(JSON.stringify(res, null, 2));
   typia.assert(res);
 };

--- a/test/features/api/connector/figma/test_api_connector_figma.ts
+++ b/test/features/api/connector/figma/test_api_connector_figma.ts
@@ -4,11 +4,6 @@ import CApi from "@wrtn/connector-api/lib/index";
 
 import { ConnectorGlobal } from "../../../../../src/ConnectorGlobal";
 
-const requestBody = {
-  secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
-  fileKey: ConnectorGlobal.env.FIGMA_TEST_FILE_KEY,
-};
-
 export const test_api_connector_figma_read_file = async (
   connection: CApi.IConnection,
 ) => {
@@ -16,10 +11,10 @@ export const test_api_connector_figma_read_file = async (
    * read file API
    */
   const readFileEvent =
-    await CApi.functional.connector.figma.get_files.readFiles(
-      connection,
-      requestBody,
-    );
+    await CApi.functional.connector.figma.get_files.readFiles(connection, {
+      secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+      fileKey: ConnectorGlobal.env.FIGMA_TEST_FILE_KEY,
+    });
 
   typia.assertEquals(readFileEvent);
 };
@@ -34,7 +29,8 @@ export const test_api_connector_figma_read_comment = async (
     await CApi.functional.connector.figma.get_comments.readComments(
       connection,
       {
-        ...requestBody,
+        secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+        fileKey: ConnectorGlobal.env.FIGMA_TEST_FILE_KEY,
         as_md: true,
       },
     );
@@ -51,7 +47,8 @@ export const test_api_connector_figma_add_comment = async (
    */
   const addCommentEvent =
     await CApi.functional.connector.figma.comments.addComment(connection, {
-      ...requestBody,
+      secretKey: ConnectorGlobal.env.FIGMA_TEST_SECRET,
+      fileKey: ConnectorGlobal.env.FIGMA_TEST_FILE_KEY,
       message: typia.random<string>(),
     });
 
@@ -89,7 +86,7 @@ export const test_api_connector_figma_get_project_files = async (
 
   for await (const project of team.projects) {
     const files =
-      await CApi.functional.connector.figma.projects.get_files.getProjectFiles(
+      await CApi.functional.connector.figma.projects.get_canvas.getProjectCanvas(
         connection,
         project.id,
         {


### PR DESCRIPTION
# implements
- 피그마에서 팀 아이디만 있으면 모든 캔버스를 가져오는 로직을 작성하였습니다.
- 피그마에서 팀 아이디만 있으면 해당 팀의 모든 프로젝트의, 모든 캔버스에서 댓글을 가져와 토론자와 가장 말이 많은 사람이 누군지 알 수 있게 통계를 조회하는 기능을 만들었습니다.

# CheckList
- [x] passed test code
- [x] api tags
- [x] RouteIcon
- [x] docs (summary, input, returns )
