### PR TITLE
기상청 데이터에 대한 격자 좌표 대응 및 주요 도시 테스트 추가

### DIFF
--- a/src/api/structures/connector/open_data/IOpenData.ts
+++ b/src/api/structures/connector/open_data/IOpenData.ts
@@ -295,96 +295,131 @@ export namespace IOpenData {
       };
     }
   }
+}
+
+/**
+ * @title 기상청 타입
+ */
+export namespace IKoreaMeteorologicalAdministration {
+  /**
+   * @title 단기 예보에서 표현되는 코드 값.
+   */
+  export type CategoryType =
+    | tags.Constant<"POP", { title: "강수확률"; description: "단위는 %" }>
+    | tags.Constant<"PTY", { title: "강수형태"; description: "코드 값" }>
+    | tags.Constant<"PCP", { title: "1시간 강수량"; description: "범주(1mm)" }>
+    | tags.Constant<"REH", { title: "습도"; description: "단위는 %" }>
+    | tags.Constant<"SNO", { title: "1시간 신적설"; description: "범주(1cm)" }>
+    | tags.Constant<"SKY", { title: "하늘 상태"; description: "코드 값" }>
+    | tags.Constant<"TMP", { title: "1시간 기온"; description: "섭씨 온도" }>
+    | tags.Constant<"TMN", { title: "일 최저기온"; description: "섭씨 온도" }>
+    | tags.Constant<"TMX", { title: "일 최고기온"; description: "섭씨 온도" }>
+    | tags.Constant<"UUU", { title: "풍속 (동서성분)"; description: "m/s" }>
+    | tags.Constant<"VVV", { title: "풍속 (남북성분)"; description: "m/s" }>
+    | tags.Constant<"WAV", { title: "파고 (파도높이)"; description: "M" }>
+    | tags.Constant<"VEC", { title: "풍향"; description: "각도 (deg)" }>
+    | tags.Constant<"WSD", { title: "풍속"; description: "m/s" }>
+    | tags.Constant<"T1H", { title: "기온"; description: "섭씨 온도" }>
+    | tags.Constant<"RN1", { title: "1시간 강수량"; description: "mm" }>
+    | tags.Constant<"VEC", { title: "풍향"; description: "deg" }>
+    | tags.Constant<"T1H", { title: "기온"; description: "섭씨 온도" }>;
 
   /**
-   * @title 기상청 타입
+   * @title 날씨 조회를 위한 요청 조건
    */
-  export namespace IKoreaMeteorologicalAdministration {
+  export interface IGetVillageForecastInformationInput {
     /**
-     * @title 단기 예보에서 표현되는 코드 값.
+     * @title 경도
      */
-    export type CategoryType =
-      | tags.Constant<"POP", { title: "강수확률"; description: "단위는 %" }>
-      | tags.Constant<"PTY", { title: "강수형태"; description: "코드 값" }>
-      | tags.Constant<
-          "PCP",
-          { title: "1시간 강수량"; description: "범주(1mm)" }
-        >
-      | tags.Constant<"REH", { title: "습도"; description: "단위는 %" }>
-      | tags.Constant<
-          "SNO",
-          { title: "1시간 신적설"; description: "범주(1cm)" }
-        >
-      | tags.Constant<"SKY", { title: "하늘 상태"; description: "코드 값" }>
-      | tags.Constant<"TMP", { title: "1시간 기온"; description: "섭씨 온도" }>
-      | tags.Constant<"TMN", { title: "일 최저기온"; description: "섭씨 온도" }>
-      | tags.Constant<"TMX", { title: "일 최고기온"; description: "섭씨 온도" }>
-      | tags.Constant<"UUU", { title: "풍속 (동서성분)"; description: "m/s" }>
-      | tags.Constant<"VVV", { title: "풍속 (남북성분)"; description: "m/s" }>
-      | tags.Constant<"WAV", { title: "파고 (파도높이)"; description: "M" }>
-      | tags.Constant<"VEC", { title: "풍향"; description: "각도 (deg)" }>
-      | tags.Constant<"WSD", { title: "풍속"; description: "m/s" }>
-      | tags.Constant<"T1H", { title: "기온"; description: "섭씨 온도" }>
-      | tags.Constant<"RN1", { title: "1시간 강수량"; description: "mm" }>
-      | tags.Constant<"VEC", { title: "풍향"; description: "deg" }>
-      | tags.Constant<"T1H", { title: "기온"; description: "섭씨 온도" }>;
+    nx: number;
 
     /**
-     * @title 날씨 조회를 위한 요청 조건
+     * @title 위도
      */
-    export interface IGetVillageForecastInformationInput {
-      /**
-       * @title 격자 좌표 값의 x 좌표.
-       */
-      nx: number;
+    ny: number;
+  }
 
-      /**
-       * @title 격자 좌표 값의 y 좌표.
-       */
-      ny: number;
-    }
+  /**
+   * 기상청에서 준 원래의 값
+   *
+   * @title 날씨 조회 결과
+   */
+  export interface IGetVillageForecastInformationOutput {
+    response: {
+      body: {
+        items: {
+          item: {
+            /**
+             * @title `20240619`와 같은 년,월,일자가 합성된 날짜 값.
+             */
+            baseDate: `${number}`;
 
-    /**
-     * @title 날씨 조회 결과
-     */
-    export interface IGetVillageForecastInformationOutput {
-      response: {
-        body: {
-          items: {
-            item: {
-              /**
-               * @title `20240619`와 같은 년,월,일자가 합성된 날짜 값.
-               */
-              baseDate: `${number}`;
+            /**
+             * @title `1200`와 같이 정각 시간을 나타내는 시간 값.
+             */
+            baseTime: `${number}`;
 
-              /**
-               * @title `1200`와 같이 정각 시간을 나타내는 시간 값.
-               */
-              baseTime: `${number}`;
+            /**
+             * @title 카테고리.
+             */
+            category: IKoreaMeteorologicalAdministration.CategoryType;
 
-              /**
-               * @title 카테고리.
-               */
-              category: IKoreaMeteorologicalAdministration.CategoryType;
+            /**
+             * @title 경도
+             */
+            nx: number;
 
-              /**
-               * @title 격자 좌표 값의 x 좌표.
-               */
-              nx: number;
+            /**
+             * @title 격자 좌표 값의 y 좌표.
+             */
+            ny: number;
 
-              /**
-               * @title 격자 좌표 값의 y 좌표.
-               */
-              ny: number;
-
-              /**
-               * @title 카테고리에 해당하는 값.
-               */
-              obsrValue: `${number}`;
-            }[];
-          };
+            /**
+             * @title 카테고리에 해당하는 값.
+             */
+            obsrValue: `${number}`;
+          }[];
         };
       };
-    }
+    };
+  }
+
+  /**
+   * 뤼튼에서 가공한 결과
+   *
+   * @title 날씨 조회 결과
+   */
+  export interface IGetForecastOutput {
+    /**
+     * @title `20240619`와 같은 년,월,일자가 합성된 날짜 값
+     */
+    baseDate: `${number}`;
+
+    /**
+     * @title `1200`와 같이 정각 시간을 나타내는 시간 값
+     */
+    baseTime: `${number}`;
+
+    /**
+     * 각 수치가 무엇을 의미하는지에 대한 분류 값을 의미
+     *
+     * @title 카테고리
+     */
+    category: IKoreaMeteorologicalAdministration.CategoryType;
+
+    /**
+     * @title 경도
+     */
+    nx: number;
+
+    /**
+     * @title 위도
+     */
+    ny: number;
+
+    /**
+     * @title 카테고리에 해당하는 값
+     */
+    obsrValue: `${number}`;
   }
 }

--- a/src/controllers/connector/open_data/OpenDataController.ts
+++ b/src/controllers/connector/open_data/OpenDataController.ts
@@ -6,7 +6,10 @@ import { RouteIcon, Standalone } from "@wrtnio/decorators";
 import { ILH } from "@wrtn/connector-api/lib/structures/connector/open_data/ILH";
 import { IMOLIT } from "@wrtn/connector-api/lib/structures/connector/open_data/IMOLIT";
 import { INIA } from "@wrtn/connector-api/lib/structures/connector/open_data/INIA";
-import { IOpenData } from "@wrtn/connector-api/lib/structures/connector/open_data/IOpenData";
+import {
+  IKoreaMeteorologicalAdministration,
+  IOpenData,
+} from "@wrtn/connector-api/lib/structures/connector/open_data/IOpenData";
 import { KoreaCopyrightCommission } from "@wrtn/connector-api/lib/structures/connector/open_data/KoreaCopyrightCommission";
 
 import { OpenDataProvider } from "../../../providers/connector/open_data/OpenDataProvider";
@@ -169,6 +172,30 @@ export class OpenDataController {
   /**
    * [기상청] 오늘 날씨를 조회합니다.
    *
+   * 조회 시 위도와 경도 좌표가 필요합니다.
+   * 입력 시 위도와 경도를 입력하면 해당 지역의 날씨 값을 매 시각의 00분을 기준으로 현재 날씨를 조회해줍니다.
+   * 출력 시에는 격좌 좌표 대신 위경도로 변환하여, 각 지역의 날씨부터 풍향, 풍속 등 날씨와 연관된 정보들을 모두 제공해줍니다.
+   * 제공해주는 정보는 현재 아래와 같습니다.
+   *
+   * - POP : 강수확률
+   * - PTY : 강수형태
+   * - PCP : 1시간 강수량
+   * - REH : 습도
+   * - SNO : 1시간 신적설
+   * - SKY : 하늘 상태
+   * - TMP : 1시간 기온
+   * - TMN : 일 최저기온
+   * - TMX : 일 최고기온
+   * - UUU : 풍속 (동서성분)
+   * - VVV : 풍속 (남북성분)
+   * - WAV : 파고 (파도높이)
+   * - VEC : 풍향
+   * - WSD : 풍속
+   * - T1H : 기온
+   * - RN1 : 1시간 강수량
+   * - VEC : 풍향
+   * - T1H : 기온
+   *
    * @summary 기상청 오늘 날씨 조회
    *
    * @param input 날씨 조회를 위한 위치 정보 DTO
@@ -182,8 +209,8 @@ export class OpenDataController {
   @TypedRoute.Post("getShortTermForecast")
   async getShortTermForecast(
     @TypedBody()
-    input: IOpenData.IKoreaMeteorologicalAdministration.IGetVillageForecastInformationInput,
-  ): Promise<IOpenData.IKoreaMeteorologicalAdministration.IGetVillageForecastInformationOutput> {
+    input: IKoreaMeteorologicalAdministration.IGetVillageForecastInformationInput,
+  ): Promise<IKoreaMeteorologicalAdministration.IGetForecastOutput[]> {
     return retry(() => OpenDataProvider.getShortTermForecast(input))();
   }
 

--- a/test/features/api/connector/open_data/test_api_connector_open_data.ts
+++ b/test/features/api/connector/open_data/test_api_connector_open_data.ts
@@ -2,20 +2,6 @@ import typia from "typia";
 
 import CApi from "@wrtn/connector-api/lib/index";
 
-export const test_api_connector_open_data_get_short_term_forecast = async (
-  connection: CApi.IConnection,
-) => {
-  const res = await CApi.functional.connector.open_data.getShortTermForecast(
-    connection,
-    {
-      nx: 60,
-      ny: 127,
-    },
-  );
-
-  typia.assertEquals(res);
-};
-
 export const test_api_connector_open_data_get_get_stock_price_info = async (
   connection: CApi.IConnection,
 ) => {

--- a/test/features/api/connector/open_data/test_api_connector_open_data_short_term_forecast.ts
+++ b/test/features/api/connector/open_data/test_api_connector_open_data_short_term_forecast.ts
@@ -1,0 +1,94 @@
+import CApi from "@wrtn/connector-api/lib/index";
+import typia from "typia";
+
+export const test_api_connector_open_data_get_short_term_forecast_1 = async (
+  connection: CApi.IConnection,
+) => {
+  const seoul = await CApi.functional.connector.open_data.getShortTermForecast(
+    connection,
+    {
+      nx: 126.978,
+      ny: 37.5665,
+    },
+  );
+
+  typia.assertEquals(seoul);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_2 = async (
+  connection: CApi.IConnection,
+) => {
+  const busan = await CApi.functional.connector.open_data.getShortTermForecast(
+    connection,
+    {
+      nx: 129.0756,
+      ny: 35.1796,
+    },
+  );
+
+  typia.assertEquals(busan);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_3 = async (
+  connection: CApi.IConnection,
+) => {
+  const daegu = await CApi.functional.connector.open_data.getShortTermForecast(
+    connection,
+    {
+      nx: 128.6014,
+      ny: 35.8714,
+    },
+  );
+
+  typia.assertEquals(daegu);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_4 = async (
+  connection: CApi.IConnection,
+) => {
+  const incheon =
+    await CApi.functional.connector.open_data.getShortTermForecast(connection, {
+      nx: 126.8529,
+      ny: 37.4563,
+    });
+
+  typia.assertEquals(incheon);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_5 = async (
+  connection: CApi.IConnection,
+) => {
+  const gwangju =
+    await CApi.functional.connector.open_data.getShortTermForecast(connection, {
+      nx: 126.8526,
+      ny: 37.1595,
+    });
+
+  typia.assertEquals(gwangju);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_6 = async (
+  connection: CApi.IConnection,
+) => {
+  const daejeon =
+    await CApi.functional.connector.open_data.getShortTermForecast(connection, {
+      nx: 127.3845,
+      ny: 36.3504,
+    });
+
+  typia.assertEquals(daejeon);
+};
+
+export const test_api_connector_open_data_get_short_term_forecast_7 = async (
+  connection: CApi.IConnection,
+) => {
+  const ulsan = await CApi.functional.connector.open_data.getShortTermForecast(
+    connection,
+    {
+      nx: 129.3114,
+      ny: 35.5384,
+    },
+  );
+
+  typia.assertEquals(ulsan);
+};


### PR DESCRIPTION
- 입출력 간 위경도를 받고, 또한 제공해줄 수 있도록 내부에서만 격자좌표를 사용하게 수정하였습니다.
- 격자좌표에 대한 수식은 기상청 코드를 기반으로 작성하였습니다.