### PR TITLE
fix: 카카오맵 응답 데이터에 빈 문자열이 나오는 문제 수정

### DIFF
--- a/src/api/structures/connector/kakao_map/IKakaoMap.ts
+++ b/src/api/structures/connector/kakao_map/IKakaoMap.ts
@@ -174,7 +174,8 @@ export namespace IKakaoMap {
     | tags.Constant<"FD6", { title: "음식점" }>
     | tags.Constant<"CE7", { title: "카페" }>
     | tags.Constant<"HP8", { title: "병원" }>
-    | tags.Constant<"PM9", { title: "약국" }>;
+    | tags.Constant<"PM9", { title: "약국" }>
+    | tags.Constant<"", { title: "알수 없음" }>;
 
   /**
    * @title 카테고리 그룹 이름
@@ -197,5 +198,6 @@ export namespace IKakaoMap {
     | tags.Constant<"음식점", { title: "음식점" }>
     | tags.Constant<"카페", { title: "카페" }>
     | tags.Constant<"병원", { title: "병원" }>
-    | tags.Constant<"약국", { title: "약국" }>;
+    | tags.Constant<"약국", { title: "약국" }>
+    | tags.Constant<"", { title: "알수 없음" }>;
 }


### PR DESCRIPTION
서울 시청과 같은 값을 검색했을 때 빈문자열이 나오는 이슈.