### PR TITLE
Add Dropbox Integration

### DIFF
--- a/src/api/structures/connector/dropbox/IDropbox.ts
+++ b/src/api/structures/connector/dropbox/IDropbox.ts
@@ -1,0 +1,33 @@
+export namespace IDropbox {
+  export interface IUploadFileInput {
+    /** 
+     * @title Access Token
+     * 
+     * The access token for Dropbox API authentication.
+     */
+    accessToken: string;
+
+    /** 
+     * @title File Path
+     * 
+     * The path where the file will be uploaded in Dropbox.
+     */
+    path: string;
+
+    /** 
+     * @title File Content
+     * 
+     * The content of the file to be uploaded.
+     */
+    content: Buffer;
+  }
+
+  export interface IUploadFileOutput {
+    /** 
+     * @title File Metadata
+     * 
+     * Metadata of the uploaded file.
+     */
+    metadata: any;
+  }
+}

--- a/src/controllers/connectors/dropbox/DropboxController.ts
+++ b/src/controllers/connectors/dropbox/DropboxController.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@nestjs/common';
+import { DropboxProvider } from '../providers/dropbox/DropboxProvider';
+import { IDropbox } from '../api/structures/connector/dropbox/IDropbox';
+
+@Controller()
+class DropboxController {
+  constructor(private readonly dropboxProvider: DropboxProvider) {}
+
+  /**
+   * Upload a file to Dropbox.
+   *
+   * This connector uploads a file to the user's Dropbox account.
+   *
+   * @summary Upload File to Dropbox
+   */
+  @core.TypedRoute.Post("upload-file")
+  async uploadFile(
+    @TypedBody() input: IDropbox.IUploadFileInput,
+  ): Promise<IDropbox.IUploadFileOutput> {
+    return this.dropboxProvider.uploadFile(input);
+  }
+}

--- a/src/providers/dropbox/DropboxProvider.ts
+++ b/src/providers/dropbox/DropboxProvider.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+import { IDropbox } from '../api/structures/connector/dropbox/IDropbox';
+
+@Injectable()
+export class DropboxProvider {
+  async uploadFile(input: IDropbox.IUploadFileInput): Promise<IDropbox.IUploadFileOutput> {
+    const res = await axios.post('https://api.dropboxapi.com/2/files/upload', input, {
+      headers: {
+        'Authorization': `Bearer ${input.accessToken}`,
+        'Content-Type': 'application/octet-stream',
+        'Dropbox-API-Arg': JSON.stringify({
+          path: input.path,
+          mode: 'add',
+          autorename: true,
+          mute: false
+        })
+      }
+    });
+    return res.data;
+  }
+}


### PR DESCRIPTION
This pull request introduces Dropbox integration into the connectors repository. It includes a new controller, provider, and types for handling file uploads to Dropbox. The integration allows users to upload files directly to their Dropbox accounts from the application, enhancing the functionality and versatility of the connectors. By merging this PR, we provide users with a seamless way to manage files across different platforms, leveraging Dropbox's robust file storage capabilities. This feature is expected to improve user experience by offering more options for file management and storage.