### PR TITLE
Revert "지라 익명 타입 제거"

### DIFF
--- a/src/api/structures/connector/jira/IJira.ts
+++ b/src/api/structures/connector/jira/IJira.ts
@@ -159,10 +159,6 @@ export namespace IJira {
   }
 
   export interface IGetCommentInput
-    extends StrictOmit<IJira.__IGetCommentInput, "domain" | "email" | "token">,
-      IJira.IBasicSecret {}
-
-  export interface __IGetCommentInput
     extends BasicAuthorization,
       ICommonPaginationInput {
     /**
@@ -186,14 +182,7 @@ export namespace IJira {
           }>);
   }
 
-  export interface IDeleteCommentInput
-    extends StrictOmit<
-        IJira.__IDeleteCommentInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IDeleteCommentInput extends BasicAuthorization {
+  export interface IDeleteCommentInput extends BasicAuthorization {
     /**
      * This connector doesn't matter the key or ID of the issue.
      * If you hand over one of them, you can use it to look up.
@@ -232,25 +221,6 @@ export namespace IJira {
         ICreateCommentInput,
         "body" | "domain" | "email" | "token"
       >,
-      IJira.IBasicSecret {
-    /**
-     * @title body of comment
-     */
-    body: StrictOmit<Comment["body"], "content"> & {
-      /**
-       * You must use markdown format string.
-       *
-       * It is recommended to contain as much detail as possible on the issue raised by the user,
-       * so that the next person who reads this issue can see the summary and description of this issue to resolve the issue.
-       *
-       * @title contents of description
-       */
-      content: string;
-    };
-  }
-
-  export interface __ICreateCommentByMarkdownInput
-    extends StrictOmit<ICreateCommentInput, "body">,
       IJira.IBasicSecret {
     /**
      * @title body of comment
@@ -330,14 +300,7 @@ export namespace IJira {
     }[];
   }
 
-  export interface IUpdateStatusInput
-    extends StrictOmit<
-        IJira.__IUpdateStatusInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IUpdateStatusInput extends BasicAuthorization {
+  export interface IUpdateStatusInput extends BasicAuthorization {
     /**
      * This connector doesn't matter the key or ID of the issue.
      * If you hand over one of them, you can use it to look up.
@@ -369,13 +332,7 @@ export namespace IJira {
       }>;
   }
 
-  export interface IGetTransitionInput
-    extends StrictOmit<
-        IJira.__IGetTransitionInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-  export interface __IGetTransitionInput extends BasicAuthorization {
+  export interface IGetTransitionInput extends BasicAuthorization {
     /**
      * This connector doesn't matter the key or ID of the issue.
      * If you hand over one of them, you can use it to look up.
@@ -397,17 +354,9 @@ export namespace IJira {
           }>);
   }
 
-  export interface IUnAssignInput
-    extends StrictOmit<IJira.__IUnAssignInput, "domain" | "email" | "token">,
-      IJira.IBasicSecret {}
+  export type IUnAssignInput = StrictOmit<IAssignInput, "asigneeId">;
 
-  export type __IUnAssignInput = StrictOmit<__IAssignInput, "asigneeId">;
-
-  export interface IAssignInput
-    extends StrictOmit<IJira.__IAssignInput, "domain" | "email" | "token">,
-      IJira.IBasicSecret {}
-
-  export interface __IAssignInput extends BasicAuthorization {
+  export interface IAssignInput extends BasicAuthorization {
     /**
      * @title ID of issue
      */
@@ -492,14 +441,10 @@ export namespace IJira {
     body: Comment["body"];
   }
 
-  export interface IUpdateIssueInput
-    extends StrictOmit<IJira.__IUpdateIssueInput, "domain" | "email" | "token">,
-      IJira.IBasicSecret {}
-
   /**
    * @title Issue update Conditions
    */
-  export interface __IUpdateIssueInput
+  export interface IUpdateIssueInput
     extends BasicAuthorization,
       MyPartial<
         StrictOmit<ICreateIssueInput, keyof BasicAuthorization | "fields">
@@ -574,6 +519,14 @@ export namespace IJira {
          */
         content: string;
       };
+
+      /**
+       * date format type.
+       * Indicates the schedule you want to be closed.Of course, it will be good to create a date or today.
+       *
+       * @title due date
+       */
+      duedate?: string & tags.Format<"date">;
 
       /**
        * @title issuetype
@@ -889,26 +842,12 @@ export namespace IJira {
   }
 
   export interface IGetIssueLabelInput
-    extends StrictOmit<
-        IJira.__IGetIssueLabelInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueLabelInput
     extends BasicAuthorization,
       ICommonPaginationInput {}
 
   export type IGetIssuePriorityOutput = MyPick<Priority, "id" | "name">[];
 
-  export interface IGetIssuePriorityInput
-    extends StrictOmit<
-        IJira.__IGetIssuePriorityInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export type __IGetIssuePriorityInput = BasicAuthorization;
+  export type IGetIssuePriorityInput = BasicAuthorization;
 
   export interface IGetIssueStatusOutput {
     /**
@@ -922,14 +861,7 @@ export namespace IJira {
     })[];
   }
 
-  export interface IGetIssueStatusInput
-    extends StrictOmit<
-        IJira.__IGetIssueStatusInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueStatusInput extends BasicAuthorization {
+  export interface IGetIssueStatusInput extends BasicAuthorization {
     /**
      * If the status does not have the project ID,
      * it means this status is beyond the scope of the project and can be selected by the entire team.
@@ -1827,14 +1759,7 @@ export namespace IJira {
     | MentionNode
     | TextContent;
 
-  export interface IGetIssueDetailInput
-    extends StrictOmit<
-        IJira.__IGetIssueDetailInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueDetailInput extends BasicAuthorization {
+  export interface IGetIssueDetailInput extends BasicAuthorization {
     /**
      * This connector doesn't matter the key or ID of the issue.
      * If you hand over one of them, you can use it to look up.
@@ -1857,13 +1782,6 @@ export namespace IJira {
   }
 
   export interface IGetIssueInputByBasicAuth
-    extends StrictOmit<
-        IJira.__IGetIssueInputByBasicAuth,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueInputByBasicAuth
     extends BasicAuthorization,
       ICommonPaginationInput,
       IGetIssueCommonRequestInput {}
@@ -1879,13 +1797,6 @@ export namespace IJira {
   >[];
 
   export interface IGetIssueAssignableInput
-    extends StrictOmit<
-        IJira.__IGetIssueAssignableInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueAssignableInput
     extends ICommonPaginationInput,
       BasicAuthorization {
     /**
@@ -1927,23 +1838,9 @@ export namespace IJira {
 
   export type IGetStatusCategoryOutput = StatusCategory[];
 
-  export interface IGetStatusCategoryInput
-    extends StrictOmit<
-        IJira.__IGetStatusCategoryInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export type __IGetStatusCategoryInput = BasicAuthorization;
+  export type IGetStatusCategoryInput = BasicAuthorization;
 
   export interface IGetProjectAssignableInput
-    extends StrictOmit<
-        IJira.__IGetProjectAssignableInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetProjectAssignableInput
     extends ICommonPaginationInput,
       BasicAuthorization {
     /**
@@ -1973,14 +1870,7 @@ export namespace IJira {
     issuetypes: IssueType[];
   }
 
-  export interface IGetIssueTypeInput
-    extends StrictOmit<
-        IJira.__IGetIssueTypeInput,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetIssueTypeInput extends BasicAuthorization {
+  export interface IGetIssueTypeInput extends BasicAuthorization {
     /**
      * @title id of project
      */
@@ -1993,13 +1883,6 @@ export namespace IJira {
   }
 
   export interface IGetProjectInputByBasicAuth
-    extends StrictOmit<
-        IJira.__IGetProjectInputByBasicAuth,
-        "domain" | "email" | "token"
-      >,
-      IJira.IBasicSecret {}
-
-  export interface __IGetProjectInputByBasicAuth
     extends BasicAuthorization,
       ICommonPaginationInput {
     /**

--- a/src/controllers/connector/jira/JiraController.ts
+++ b/src/controllers/connector/jira/JiraController.ts
@@ -1,9 +1,10 @@
 import core, { TypedBody, TypedParam } from "@nestia/core";
 import { Controller } from "@nestjs/common";
-import { ApiTags } from "@nestjs/swagger";
 import type { IJira } from "@wrtn/connector-api/lib/structures/connector/jira/IJira";
 import { RouteIcon } from "@wrtnio/decorators";
 import { JiraProvider } from "../../../providers/connector/jira/JiraProvider";
+import { StrictOmit } from "../../../api/structures/types/strictOmit";
+import { ApiTags } from "@nestjs/swagger";
 
 @Controller("connector/jira")
 export class JiraController {
@@ -25,7 +26,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Delete("issues/comments")
   async deleteComment(
-    @TypedBody() input: IJira.IDeleteCommentInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IDeleteCommentInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<void> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -72,7 +75,8 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("issues/comments/markdown")
   async createComment(
-    @TypedBody() input: IJira.ICreateCommentByMarkdownInput,
+    @TypedBody()
+    input: IJira.ICreateCommentByMarkdownInput,
   ): Promise<IJira.ICreateCommentOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -99,7 +103,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("issues/get-comments")
   async getComments(
-    @TypedBody() input: IJira.IGetCommentInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IGetCommentInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetCommentOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -125,7 +131,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("issues/get-transitions")
   async getTransitions(
-    @TypedBody() input: IJira.IGetTransitionInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IGetTransitionInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetTransitionOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -146,7 +154,11 @@ export class JiraController {
   )
   @ApiTags("Jira")
   @core.TypedRoute.Delete("issues/asignee")
-  async unassign(@TypedBody() input: IJira.IUnAssignInput): Promise<void> {
+  async unassign(
+    @TypedBody()
+    input: StrictOmit<IJira.IUnAssignInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
+  ): Promise<void> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
       secretKey: secretValue,
@@ -166,7 +178,11 @@ export class JiraController {
   )
   @ApiTags("Jira")
   @core.TypedRoute.Put("issues/asignee")
-  async assign(@TypedBody() input: IJira.IAssignInput): Promise<void> {
+  async assign(
+    @TypedBody()
+    input: StrictOmit<IJira.IAssignInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
+  ): Promise<void> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
       secretKey: secretValue,
@@ -190,7 +206,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Put("issues/status")
   async updateIssueStatus(
-    @TypedBody() input: IJira.IUpdateStatusInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IUpdateStatusInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<void> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -219,7 +237,9 @@ export class JiraController {
   @core.TypedRoute.Put("issues/:id")
   async updateIssue(
     @TypedParam("id") id: IJira.Issue["id"],
-    @TypedBody() input: IJira.IUpdateIssueInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IUpdateIssueInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<void> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -259,6 +279,33 @@ export class JiraController {
     });
   }
 
+  //
+  //  * Create an issue
+  //  *
+  //  * Issue type, project, and summary are essential properties.
+  //  * If you don't know the issue type or priority type's id for generating the issue, you can look it up through other connectors.
+  //  *
+  //  * In order to write the body of an issue, you must create the body as if you were assembling several blocks.
+  //  * There are pre-designated content types, so please check this type information carefully.
+  //  *
+  //  * @summary create issue in jira
+  //  * @param input issue information to create
+  //  * @returns id and key of created issue
+  //  */
+  // @RouteIcon(
+  //   `https://ecosystem-connector.s3.ap-northeast-2.amazonaws.com/icon/fulls/JIraCloud_full.svg`,
+  // )
+  // @core.TypedRoute.Post("issues")
+  // async createIssue(
+  //   @TypedBody() input: IJira.ICreateIssueInputWithBasicAuth,
+  // ): Promise<IJira.ICreateIssueOutput> {
+  //   const secretValue = await this.jiraProvider.getToken(input.secretKey);
+  //   const authorization = this.jiraProvider.parseSecretKey({
+  //     secretKey: secretValue,
+  //   });
+  //   return this.jiraProvider.createIssue({ ...input, ...authorization });
+  // }
+
   /**
    * Get detailed issue information
    *
@@ -277,7 +324,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-issue-detail")
   async getIssueDetail(
-    @TypedBody() input: IJira.IGetIssueDetailInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetIssueDetailInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueDetailOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -302,7 +354,11 @@ export class JiraController {
   @core.TypedRoute.Post("get-issues")
   async getIssues(
     @TypedBody()
-    input: IJira.IGetIssueInputByBasicAuth,
+    input: StrictOmit<
+      IJira.IGetIssueInputByBasicAuth,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -330,7 +386,11 @@ export class JiraController {
   @core.TypedRoute.Post("get-projects")
   async getProjects(
     @TypedBody()
-    input: IJira.IGetProjectInputByBasicAuth,
+    input: StrictOmit<
+      IJira.IGetProjectInputByBasicAuth,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetProjectOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -352,7 +412,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-issue-labels")
   async getIssueLabels(
-    @TypedBody() input: IJira.IGetIssueLabelInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IGetIssueLabelInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueLabelOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -379,7 +441,9 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-issue-types")
   async getIssueTypes(
-    @TypedBody() input: IJira.IGetIssueTypeInput,
+    @TypedBody()
+    input: StrictOmit<IJira.IGetIssueTypeInput, "domain" | "email" | "token"> &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueTypeOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -401,7 +465,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-issue-statuses")
   async getIssueStatus(
-    @TypedBody() input: IJira.IGetIssueStatusInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetIssueStatusInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueStatusOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -426,7 +495,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-issue-priorities")
   async getIssuePriorities(
-    @TypedBody() input: IJira.IGetIssuePriorityInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetIssuePriorityInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssuePriorityOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -448,7 +522,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("issues/get-users-assignable")
   async getUsersAssignableInIssue(
-    @TypedBody() input: IJira.IGetIssueAssignableInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetIssueAssignableInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetIssueAssignableOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -473,7 +552,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("projects/get-users-assignable")
   async getUsersAssignableInProject(
-    @TypedBody() input: IJira.IGetProjectAssignableInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetProjectAssignableInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetProjectAssignableOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({
@@ -498,7 +582,12 @@ export class JiraController {
   @ApiTags("Jira")
   @core.TypedRoute.Post("get-status-categories")
   async getStatusCategories(
-    @TypedBody() input: IJira.IGetStatusCategoryInput,
+    @TypedBody()
+    input: StrictOmit<
+      IJira.IGetStatusCategoryInput,
+      "domain" | "email" | "token"
+    > &
+      IJira.IBasicSecret,
   ): Promise<IJira.IGetStatusCategoryOutput> {
     const secretValue = await this.jiraProvider.getToken(input.secretKey);
     const authorization = this.jiraProvider.parseSecretKey({

--- a/src/providers/connector/jira/JiraProvider.ts
+++ b/src/providers/connector/jira/JiraProvider.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import type { IJira } from "@wrtn/connector-api/lib/structures/connector/jira/IJira";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import typia from "typia";
 import { ConnectorGlobal } from "../../../ConnectorGlobal";
 import { createQueryParameter } from "../../../utils/CreateQueryParameter";
@@ -11,7 +11,7 @@ import { IOAuthSecret } from "../../internal/oauth_secret/structures/IOAuthSecre
 @Injectable()
 export class JiraProvider {
   async getUsersAssignableInIssue(
-    input: IJira.__IGetIssueAssignableInput,
+    input: IJira.IGetIssueAssignableInput,
   ): Promise<IJira.IGetIssueAssignableOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -30,17 +30,13 @@ export class JiraProvider {
       });
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getStatusCategories(
-    input: IJira.__IGetStatusCategoryInput,
+    input: IJira.IGetStatusCategoryInput,
   ): Promise<IJira.IGetStatusCategoryOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -53,17 +49,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getUsersAssignableInProject(
-    input: IJira.__IGetProjectAssignableInput,
+    input: IJira.IGetProjectAssignableInput,
   ): Promise<IJira.IGetProjectAssignableOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -80,17 +72,13 @@ export class JiraProvider {
       });
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssueStatuses(
-    input: IJira.__IGetIssueStatusInput,
+    input: IJira.IGetIssueStatusInput,
   ): Promise<IJira.IGetIssueStatusOutput> {
     try {
       const projectId = input.projectId;
@@ -118,17 +106,13 @@ export class JiraProvider {
           }),
       };
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssueLabels(
-    input: IJira.__IGetIssueLabelInput,
+    input: IJira.IGetIssueLabelInput,
   ): Promise<IJira.IGetIssueLabelOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -141,17 +125,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssuePriorities(
-    input: IJira.__IGetIssuePriorityInput,
+    input: IJira.IGetIssuePriorityInput,
   ): Promise<IJira.IGetIssuePriorityOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -164,17 +144,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssueTypes(
-    input: IJira.__IGetIssueTypeInput,
+    input: IJira.IGetIssueTypeInput,
   ): Promise<IJira.IGetIssueTypeOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -187,18 +163,14 @@ export class JiraProvider {
 
       return { issuetypes: res.data };
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getProjects(
     input:
-      | IJira.__IGetProjectInputByBasicAuth
+      | IJira.IGetProjectInputByBasicAuth
       | IJira.IGetProjectInputBySecretKey,
   ) {
     try {
@@ -218,17 +190,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssueDetail(
-    input: IJira.__IGetIssueDetailInput,
+    input: IJira.IGetIssueDetailInput,
   ): Promise<IJira.IGetIssueDetailOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -244,17 +212,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getIssues(
-    input: IJira.__IGetIssueInputByBasicAuth | IJira.IGetIssueInputBySecretKey,
+    input: IJira.IGetIssueInputByBasicAuth | IJira.IGetIssueInputBySecretKey,
   ): Promise<IJira.IGetIssueOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -286,11 +250,7 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
@@ -375,16 +335,12 @@ export class JiraProvider {
 
       return res.data as { access_token: string };
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
-  async deleteComment(input: IJira.__IDeleteCommentInput): Promise<void> {
+  async deleteComment(input: IJira.IDeleteCommentInput): Promise<void> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
       await axios.delete(
@@ -396,17 +352,13 @@ export class JiraProvider {
         },
       );
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async createComment(
-    input: IJira.__ICreateCommentByMarkdownInput,
+    input: IJira.ICreateCommentByMarkdownInput,
   ): Promise<IJira.ICreateCommentOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -435,17 +387,13 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getComments(
-    input: IJira.__IGetCommentInput,
+    input: IJira.IGetCommentInput,
   ): Promise<IJira.IGetCommentOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -461,16 +409,12 @@ export class JiraProvider {
       );
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
-  async unassign(input: IJira.__IUnAssignInput): Promise<void> {
+  async unassign(input: IJira.IUnAssignInput): Promise<void> {
     try {
       await this.updateIssue(input.issueId, {
         email: input.email,
@@ -483,16 +427,12 @@ export class JiraProvider {
         },
       });
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
-  async assign(input: IJira.__IAssignInput): Promise<void> {
+  async assign(input: IJira.IAssignInput): Promise<void> {
     try {
       await this.updateIssue(input.issueId, {
         email: input.email,
@@ -505,17 +445,13 @@ export class JiraProvider {
         },
       });
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async getTransitions(
-    input: IJira.__IGetTransitionInput,
+    input: IJira.IGetTransitionInput,
   ): Promise<IJira.IGetTransitionOutput> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -532,16 +468,12 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
-  async updateIssueStatus(input: IJira.__IUpdateStatusInput): Promise<void> {
+  async updateIssueStatus(input: IJira.IUpdateStatusInput): Promise<void> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
       await axios.post(
@@ -560,11 +492,7 @@ export class JiraProvider {
         },
       );
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
@@ -595,18 +523,14 @@ export class JiraProvider {
         },
       );
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
 
   async updateIssue(
     id: IJira.Issue["id"],
-    input: IJira.__IUpdateIssueInput,
+    input: IJira.IUpdateIssueInput,
   ): Promise<void> {
     try {
       const config = await this.getAuthorizationAndDomain(input);
@@ -624,11 +548,7 @@ export class JiraProvider {
         },
       );
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
@@ -660,11 +580,7 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }
@@ -690,11 +606,7 @@ export class JiraProvider {
 
       return res.data;
     } catch (err) {
-      if (err instanceof AxiosError) {
-        console.error(JSON.stringify(err.response?.data));
-      } else {
-        console.error(JSON.stringify(err));
-      }
+      console.error(JSON.stringify(err));
       throw err;
     }
   }

--- a/test/features/api/connector/jira/test_api_connector_jira_create_issue_by_markdown.ts
+++ b/test/features/api/connector/jira/test_api_connector_jira_create_issue_by_markdown.ts
@@ -156,27 +156,3 @@ export class AuthService {
 
   typia.assert(res);
 };
-
-// 실패 케이스 검증
-export const test_api_connector_jira_create_issue_fail_case = async (
-  connection: CApi.IConnection,
-) => {
-  const content =
-    "This is a detailed description of the issue in markdown format.";
-  const res =
-    await CApi.functional.connector.jira.issues.markdown.createIssueByMarkdown(
-      connection,
-      {
-        secretKey: JSON.stringify(Configuration),
-        fields: {
-          description: { content, type: "doc", version: 1 },
-          issuetype: { id: "10005" },
-          priority: { id: "3" },
-          project: { id: "10001" },
-          summary: "New Issue Summary",
-        },
-      },
-    );
-
-  typia.assert(res);
-};


### PR DESCRIPTION
Reverts wrtnio/connectors#647

익명 타입 제거 후 배포하였을 때 지라 이슈 생성을 기깔나게 잘하기 때문에 다시 Revert 하여
원인이 익명 타입으로 인한 것인지 아니면 일시적인 것인지 정확히 판명하기 위해 Revert.