### PR TITLE
Trace OpenAI responses

### DIFF
--- a/test/benchmark/call/structures/IFunctionCallBenchmarkResult.ts
+++ b/test/benchmark/call/structures/IFunctionCallBenchmarkResult.ts
@@ -1,4 +1,8 @@
-import { INestiaAgentPrompt, INestiaAgentTokenUsage } from "@nestia/agent";
+import {
+  INestiaAgentEvent,
+  INestiaAgentPrompt,
+  INestiaAgentTokenUsage,
+} from "@nestia/agent";
 import { IFunctionCallBenchmarkScenario } from "./IFunctionCallBenchmarkScenario";
 
 export interface IFunctionCallBenchmarkResult {
@@ -9,6 +13,7 @@ export interface IFunctionCallBenchmarkResult {
 export namespace IFunctionCallBenchmarkResult {
   export interface ITrial {
     histories: INestiaAgentPrompt[];
+    responses: INestiaAgentEvent.IResponse[];
     usage: INestiaAgentTokenUsage;
     select: boolean;
     execute: boolean;


### PR DESCRIPTION
This pull request includes multiple changes to the benchmarking executors and structures to enhance functionality and improve code clarity. The most important changes include adding a new `responses` field to the `IFunctionCallBenchmarkResult.ITrial` interface, updating the `FunctionCallBenchmarkExecutor` to handle agent responses, and refactoring the `FunctionCallBenchmarkReporter` to accommodate the new structure and improve file handling.

Enhancements to benchmarking executors:

* [`test/benchmark/call/executors/FunctionCallBenchmarkExecutor.ts`](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R3): Added `responses` field to store agent responses and updated the executor to handle these responses during function calls. [[1]](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R3) [[2]](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R57-R58) [[3]](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R88-R90) [[4]](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R119) [[5]](diffhunk://#diff-727824f2911d420f4917eed6a8d3b935341a1d16c8b44047783caeb19fda3eb9R148)

Refactoring for improved structure and file handling:

* [`test/benchmark/call/executors/FunctionCallBenchmarkReporter.ts`](diffhunk://#diff-a1bcbea4f3617222a9f091bcbdae402720fea8bcf0e7f35c834c5f028b7da216L145-R184): Refactored `reportTrial` function to use an object parameter for better readability and maintainability. Added code to create a directory for storing response files and updated the file writing logic to include response data. [[1]](diffhunk://#diff-a1bcbea4f3617222a9f091bcbdae402720fea8bcf0e7f35c834c5f028b7da216L145-R184) [[2]](diffhunk://#diff-a1bcbea4f3617222a9f091bcbdae402720fea8bcf0e7f35c834c5f028b7da216R266-R279)

Updates to data structures:

* [`test/benchmark/call/structures/IFunctionCallBenchmarkResult.ts`](diffhunk://#diff-47f4c3c19d11ad465a7e2e9fb84e0e661e03fb035c89dc59514aa4418f8b6ffbL1-R5): Added `responses` field to the `IFunctionCallBenchmarkResult.ITrial` interface to store agent responses. [[1]](diffhunk://#diff-47f4c3c19d11ad465a7e2e9fb84e0e661e03fb035c89dc59514aa4418f8b6ffbL1-R5) [[2]](diffhunk://#diff-47f4c3c19d11ad465a7e2e9fb84e0e661e03fb035c89dc59514aa4418f8b6ffbR16)