### PR TITLE
chore(deps): update nestjs-pino for support nestjs@11

### DIFF
--- a/nestia.config.ts
+++ b/nestia.config.ts
@@ -5,6 +5,7 @@ import { OpenApi } from "@samchon/openapi";
 import { StudioModule } from "./src/StudioModule";
 import { ConnectorModule } from "./src/controllers/connector/ConnectorModule";
 import { LoggerModule } from "nestjs-pino";
+import { Type } from "@nestjs/common";
 
 const toKebabCase = (str: string) => {
   return str
@@ -14,7 +15,7 @@ const toKebabCase = (str: string) => {
 };
 
 const swagger = (props: {
-  module: Function;
+  module: Type<any>;
   info: Partial<OpenApi.IDocument.IInfo>;
   output: string;
 }): sdk.INestiaConfig => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "marked": "^14.1.2",
         "mdast-util-from-markdown": "^2.0.1",
         "mime-types": "^2.1.35",
-        "nestjs-pino": "^4.0.0",
+        "nestjs-pino": "^4.3.0",
         "notion-to-md": "^3.1.1",
         "openai": "^4.24.1",
         "pino": "^9.5.0",
@@ -17130,16 +17130,16 @@
       }
     },
     "node_modules/nestjs-pino": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nestjs-pino/-/nestjs-pino-4.1.0.tgz",
-      "integrity": "sha512-I6zcddauD2TNMRbsraEIxNUvHcz0El5QRUYH5eY1+pBzj7R17U+Yoyypoc+akVdSLWJ1r0kDYAZPy2mlhXv6vw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/nestjs-pino/-/nestjs-pino-4.3.0.tgz",
+      "integrity": "sha512-u/FRi+eRH+ER6cccyr9BBNaHg71qxLgWwDT7a0eGbSVZrSUzQ04O5zTNqydgzihNNHfuam6TBTz1wWdapOWYnQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "marked": "^14.1.2",
     "mdast-util-from-markdown": "^2.0.1",
     "mime-types": "^2.1.35",
-    "nestjs-pino": "^4.0.0",
+    "nestjs-pino": "^4.3.0",
     "notion-to-md": "^3.1.1",
     "openai": "^4.24.1",
     "pino": "^9.5.0",


### PR DESCRIPTION
# Purpose

update nestjs-pino to 4.3.0(before 4.1.0)

changes : nestjs-pino@4.3.0 can support nestjs@11


# Check List

- [ ] Passing an existing or newly created test
- [ ] sufficient summary and description for LLM to understand
- [x] Does it ensure backward compatibility with existing features, or does the modifications not affect pre-modification request, response type?
